### PR TITLE
Implement depth chart generator

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/entities/team.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/entities/team.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import List, Dict, Optional
 from gridiron_gm.gridiron_gm_pkg.simulation.entities.player import Player
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.roster.depth_chart import generate_depth_chart
 
 class Team:
     """
@@ -74,14 +75,7 @@ class Team:
         """
         Rebuilds the depth chart by grouping and sorting players by position and overall.
         """
-        self.depth_chart = {}
-        for player in self.players:
-            position = player.position
-            if position not in self.depth_chart:
-                self.depth_chart[position] = []
-            self.depth_chart[position].append(player)
-        for pos in self.depth_chart:
-            self.depth_chart[pos].sort(key=lambda p: getattr(p, "overall", 0), reverse=True)
+        self.depth_chart = generate_depth_chart(self)
 
     def get_starters(self) -> Dict[str, Player]:
         """

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/team_data.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/team_data.py
@@ -142,11 +142,7 @@ def fill_team_rosters_with_dummy_players(teams):
         team.roster = team.players
 
         # 4. Build depth_chart for all required positions
-        if not hasattr(team, "depth_chart") or team.depth_chart is None:
-            team.depth_chart = {}
-        for pos in min_positions:
-            players_for_pos = [p for p in team.players if getattr(p, "position", None) == pos]
-            team.depth_chart[pos] = players_for_pos
+        team.generate_depth_chart()
 
         # 5. Final debug output
         print(f"[ROSTER FILL] {abbr} roster filled with {len(team.roster)} players.")


### PR DESCRIPTION
## Summary
- implement functional `generate_depth_chart` to build sorted position lists
- refactor `DepthChartManager` to use generator
- call generator from `Team.generate_depth_chart`
- update team roster filler to rebuild depth charts using the generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840940397ac83279012f1bfcbd7ce52