### PR TITLE
Remove duplicate SubstitutionManagerV2 definition

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/roster/depth_chart.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/roster/depth_chart.py
@@ -56,45 +56,6 @@ class DepthChartManager:
                 overall = getattr(player, "overall", 0)
                 print(f"  {i+1}. {name} (OVR: {overall})")
 
-class SubstitutionManagerV2:
-    """
-    Handles substitutions for a team, returning a lineup by scheme and managing fatigue/bench logic.
-    """
-    def __init__(self, depth_chart: Dict[str, List[Any]]):
-        self.depth_chart = depth_chart
-
-    def get_active_lineup_with_bench_log(
-        self,
-        formation: Dict[str, int],
-        offense: Dict[str, Any],
-        fatigue_log: List[str],
-        scheme: Dict[str, int]
-    ) -> Tuple[Dict[str, Any], List[str]]:
-        """
-        Returns the lineup for the given formation, making fatigue-aware substitutions as needed.
-        Injured players are never included.
-        """
-        lineup = {}
-        bench_log = []
-        for pos, count in scheme.items():
-            depth_list = [p for p in self.depth_chart.get(pos, []) if not getattr(p, "is_injured", False)]
-            chosen = []
-            for i in range(count):
-                if i < len(depth_list):
-                    player = depth_list[i]
-                    if getattr(player, "fatigue", 0.0) >= 0.9 and len(depth_list) > i + 1:
-                        backup = depth_list[i + 1]
-                        if getattr(backup, "fatigue", 0.0) < 0.9:
-                            chosen.append(backup)
-                            bench_log.append(f"{pos}: {getattr(player, 'name', 'Unknown')} → {getattr(backup, 'name', 'Unknown')}")
-                        else:
-                            chosen.append(player)
-                    else:
-                        chosen.append(player)
-            for idx, player in enumerate(chosen, 1):
-                key = f"{pos}{idx}" if count > 1 else pos
-                lineup[key] = player
-        return lineup, bench_log
 
 def generate_depth_chart(team: Any) -> Dict[str, List[Any]]:
     """Generate a depth chart from a team or list of players.


### PR DESCRIPTION
## Summary
- keep `SubstitutionManagerV2` only in `substitution_manager.py`
- delete the older copy from `depth_chart.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409645aed88327add3f72929dfed33