### PR TITLE
Wrap debug output with VERBOSE_SIM_OUTPUT flag

### DIFF
--- a/gridiron_gm/__init__.py
+++ b/gridiron_gm/__init__.py
@@ -1,0 +1,3 @@
+
+# Global flag to control verbose simulation output across modules
+VERBOSE_SIM_OUTPUT = False

--- a/gridiron_gm/gridiron_gm_pkg/simulation/engine/penalty_engine.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/engine/penalty_engine.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import random
 from typing import List
+from gridiron_gm import VERBOSE_SIM_OUTPUT
 
 @dataclass
 class Player:
@@ -55,7 +56,8 @@ def simulate_penalty(player: Player, discipline_modifier: float = 0.0) -> str | 
         final_chance = max(base_chance + trait_modifier + discipline_penalty + discipline_modifier, MIN_PENALTY_CHANCE)
         roll = random.random()
         if roll < final_chance:
-            print(f"[DEBUG]     PENALTY TRIGGERED: {penalty} for {player.name} (chance={final_chance:.3f}, roll={roll:.3f})")
+            if VERBOSE_SIM_OUTPUT:
+                print(f"[DEBUG]     PENALTY TRIGGERED: {penalty} for {player.name} (chance={final_chance:.3f}, roll={roll:.3f})")
             return penalty
     
     return None
@@ -101,7 +103,8 @@ def simulate_play(
                 auto_first_down = False
 
             team = "offense" if getattr(player, "name", None) in offense_players else "defense"
-            print(f"[DEBUG] Penalty result: {penalty}, team={team}, yards={yards}, auto_first_down={auto_first_down}, replay_down={replay_down}")
+            if VERBOSE_SIM_OUTPUT:
+                print(f"[DEBUG] Penalty result: {penalty}, team={team}, yards={yards}, auto_first_down={auto_first_down}, replay_down={replay_down}")
 
             results.append({
                 "type": penalty,
@@ -113,7 +116,8 @@ def simulate_play(
             })
         else:
             pass
-    print(f"[DEBUG] simulate_play: Results: {results}")
+    if VERBOSE_SIM_OUTPUT:
+        print(f"[DEBUG] simulate_play: Results: {results}")
     return results
 
 @dataclass
@@ -124,14 +128,16 @@ class DriveState:
     result: str = "In Progress"
 
 def simulate_drive(players: List[Player], discipline_modifier: float = 0.0, max_plays: int = 8) -> dict:
-    print(f"[DEBUG] simulate_drive: Starting drive with {len(players)} players")
+    if VERBOSE_SIM_OUTPUT:
+        print(f"[DEBUG] simulate_drive: Starting drive with {len(players)} players")
     state = DriveState()
     penalty_log = []
     total_penalties = 0
     total_penalty_yards = 0
 
     for play_num in range(1, max_plays + 1):
-        print(f"[DEBUG] Play {play_num} -------------------")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Play {play_num} -------------------")
         penalties = simulate_play(players, discipline_modifier)
         for penalty in penalties:
             penalty_log.append(f"Play {play_num}: {penalty}")
@@ -146,7 +152,8 @@ def simulate_drive(players: List[Player], discipline_modifier: float = 0.0, max_
                 state.yards_to_go = 10
 
         gain = random.randint(5, 15)
-        print(f"[DEBUG] Play {play_num} gain: {gain}")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Play {play_num} gain: {gain}")
         state.yard_line += gain
         state.yards_to_go -= gain
 
@@ -158,21 +165,25 @@ def simulate_drive(players: List[Player], discipline_modifier: float = 0.0, max_
 
         if state.down > 4:
             state.result = "Punt"
-            print(f"[DEBUG] Drive ends: Punt")
+            if VERBOSE_SIM_OUTPUT:
+                print(f"[DEBUG] Drive ends: Punt")
             break
 
         if state.yard_line >= 100:
             state.result = "Touchdown"
-            print(f"[DEBUG] Drive ends: Touchdown")
+            if VERBOSE_SIM_OUTPUT:
+                print(f"[DEBUG] Drive ends: Touchdown")
             break
 
     if state.result == "In Progress":
         state.result = "Field Goal Attempt" if state.yard_line >= 70 else "Punt"
-        print(f"[DEBUG] Drive ends: {state.result}")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Drive ends: {state.result}")
 
-    print(f"[DEBUG] Final drive state: {state}")
-    print(f"[DEBUG] Penalty log: {penalty_log}")
-    print(f"[DEBUG] Total penalties: {total_penalties}, Total penalty yards: {total_penalty_yards}")
+    if VERBOSE_SIM_OUTPUT:
+        print(f"[DEBUG] Final drive state: {state}")
+        print(f"[DEBUG] Penalty log: {penalty_log}")
+        print(f"[DEBUG] Total penalties: {total_penalties}, Total penalty yards: {total_penalty_yards}")
     return {
         "Result": state.result,
         "Final Yard Line": state.yard_line,

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/team_data.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/team_data.py
@@ -1,5 +1,6 @@
 import json
 import random
+from gridiron_gm import VERBOSE_SIM_OUTPUT
 
 try:
     from gridiron_gm.gridiron_gm_pkg.simulation.entities.team import Team
@@ -35,13 +36,15 @@ def load_teams_from_json(json_path):
             conference=team_kwargs["conference"],
             division=team_kwargs.get("division", "Unknown"),
         )
-        print(f"[DEBUG] After conversion: {team.abbreviation} conference={team.conference}")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] After conversion: {team.abbreviation} conference={team.conference}")
         teams.append(team)
-    print("Teams loaded from JSON and their conferences:")
-    for team in teams:
-        abbr = getattr(team, "abbreviation", None)
-        conf = getattr(team, "conference", None)
-        print(f"{team.id} ({abbr}) - Conference: {conf}")
+    if VERBOSE_SIM_OUTPUT:
+        print("Teams loaded from JSON and their conferences:")
+        for team in teams:
+            abbr = getattr(team, "abbreviation", None)
+            conf = getattr(team, "conference", None)
+            print(f"{team.id} ({abbr}) - Conference: {conf}")
     return teams
 
 def fill_team_rosters_with_dummy_players(teams):
@@ -82,7 +85,8 @@ def fill_team_rosters_with_dummy_players(teams):
 
     for team in teams:
         abbr = getattr(team, 'abbreviation', 'UNK')
-        print(f"[DEBUG] Starting roster fill for {abbr}")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Starting roster fill for {abbr}")
 
         # Always start with an empty roster for deterministic fill
         if hasattr(team, "players"):
@@ -92,7 +96,8 @@ def fill_team_rosters_with_dummy_players(teams):
         # team.roster will be synced at the end
 
         # 1. Add minimum required players for each position
-        print(f"[DEBUG] Filling minimum required players for each position for {abbr}...")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Filling minimum required players for each position for {abbr}...")
         player_count = 0
         for pos, min_count in min_positions.items():
             for i in range(min_count):
@@ -110,10 +115,12 @@ def fill_team_rosters_with_dummy_players(teams):
                 player.discipline_rating = discipline_rating
                 team.add_player(player)  # Only use add_player
                 player_count += 1
-        print(f"[DEBUG] Finished minimums for {abbr}. Current roster size: {len(team.players)}")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Finished minimums for {abbr}. Current roster size: {len(team.players)}")
 
         # 2. Fill the rest of the roster with random positions
-        print(f"[DEBUG] Filling remaining roster spots for {abbr} with random positions...")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Filling remaining roster spots for {abbr} with random positions...")
         fill_attempts = 0
         max_attempts = 1000  # Prevent infinite loop
         while len(team.players) < roster_size and fill_attempts < max_attempts:
@@ -135,7 +142,8 @@ def fill_team_rosters_with_dummy_players(teams):
             player_count += 1
             fill_attempts += 1
             if len(team.players) % 5 == 0 or len(team.players) == roster_size:
-                print(f"[DEBUG] {abbr} roster length: {len(team.players)}")
+                if VERBOSE_SIM_OUTPUT:
+                    print(f"[DEBUG] {abbr} roster length: {len(team.players)}")
         if fill_attempts >= max_attempts:
             print(f"[ERROR] Roster fill for {abbr} hit max attempts! Current size: {len(team.players)}")
 

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/playoff_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/playoff_manager.py
@@ -2,6 +2,7 @@
 
 from gridiron_gm.gridiron_gm_pkg.simulation.engine.game_engine import simulate_game
 from gridiron_gm.gridiron_gm_pkg.simulation.systems.core.data_loader import save_playoff_results
+from gridiron_gm import VERBOSE_SIM_OUTPUT
 
 
 def update_playoff_schedule(schedule_by_week, playoff_results, round_name, next_round_name, conference):
@@ -16,7 +17,8 @@ def update_playoff_schedule(schedule_by_week, playoff_results, round_name, next_
             winners.append(game["away_id"])
 
     if not winners:
-        print(f"[DEBUG] No winners found for {round_name} ({conference})")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] No winners found for {round_name} ({conference})")
         return
 
     if next_round_name == "Divisional":
@@ -29,7 +31,8 @@ def update_playoff_schedule(schedule_by_week, playoff_results, round_name, next_
             winners.remove(one_seed_id)
         winners_sorted = sorted(winners)
         if len(winners_sorted) < 3:
-            print(f"[DEBUG] Not enough winners for Divisional ({conference}): {winners_sorted}")
+            if VERBOSE_SIM_OUTPUT:
+                print(f"[DEBUG] Not enough winners for Divisional ({conference}): {winners_sorted}")
             return
         for g in schedule_by_week.values():
             for game in g:
@@ -45,7 +48,8 @@ def update_playoff_schedule(schedule_by_week, playoff_results, round_name, next_
     elif next_round_name == "Conference Championship":
         winners_sorted = sorted(winners)
         if len(winners_sorted) < 2:
-            print(f"[DEBUG] Not enough winners for Conference Championship ({conference}): {winners_sorted}")
+            if VERBOSE_SIM_OUTPUT:
+                print(f"[DEBUG] Not enough winners for Conference Championship ({conference}): {winners_sorted}")
             return
         for g in schedule_by_week.values():
             for game in g:
@@ -57,7 +61,8 @@ def update_playoff_schedule(schedule_by_week, playoff_results, round_name, next_
     elif next_round_name == "Gridiron Bowl":
         winners_sorted = sorted(winners)
         if len(winners_sorted) < 2:
-            print(f"[DEBUG] Not enough winners for Gridiron Bowl: {winners_sorted}")
+            if VERBOSE_SIM_OUTPUT:
+                print(f"[DEBUG] Not enough winners for Gridiron Bowl: {winners_sorted}")
             return
         for g in schedule_by_week.values():
             for game in g:

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -20,6 +20,7 @@ from gridiron_gm.gridiron_gm_pkg.simulation.engine.game_engine import simulate_g
 
 # NEW: Import from team_data
 from gridiron_gm.gridiron_gm_pkg.simulation.systems.core.team_data import load_teams_from_json, fill_team_rosters_with_dummy_players
+from gridiron_gm import VERBOSE_SIM_OUTPUT
 
 from gridiron_gm.gridiron_gm_pkg.simulation.systems.core.data_loader import (
     load_schedule_files, save_results, save_league_state, save_playoff_bracket, save_playoff_results
@@ -28,7 +29,6 @@ from gridiron_gm.gridiron_gm_pkg.simulation.systems.core.serialization_utils imp
 from gridiron_gm.gridiron_gm_pkg.simulation.utils.generate_schedule import add_nfl_style_playoff_schedule
 from gridiron_gm.gridiron_gm_pkg.simulation.systems.game.daily_manager import DailyOperationsManager
 
-VERBOSE_SIM_OUTPUT = False
 
 try:
     from gridiron_gm.gridiron_gm_pkg.simulation.entities.team import Team
@@ -337,7 +337,8 @@ class SeasonManager:
             json.dump(self.schedule_by_week, f, indent=2)
 
         self.playoffs_generated = True
-        print("[DEBUG] Playoff schedule generated and saved.")
+        if VERBOSE_SIM_OUTPUT:
+            print("[DEBUG] Playoff schedule generated and saved.")
 
     def validate_team_rosters_and_depth_charts(self):
         """
@@ -362,16 +363,17 @@ class SeasonManager:
             for pos in required_positions:
                 if pos not in depth_chart or not depth_chart[pos]:
                     issues.append(f"Depth chart missing or empty for {pos}")
-            if issues:
-                team_name = getattr(team, "team_name", getattr(team, "name", "UNKNOWN"))
-                print(f"[VALIDATION WARNING] {team_name}: " + "; ".join(issues))
-            else:
-                team_name = getattr(team, "team_name", getattr(team, "name", "UNKNOWN"))
-                print(f"[VALIDATION OK] {team_name}: Roster and depth chart complete.")
+            team_name = getattr(team, "team_name", getattr(team, "name", "UNKNOWN"))
+            if VERBOSE_SIM_OUTPUT:
+                if issues:
+                    print(f"[VALIDATION WARNING] {team_name}: " + "; ".join(issues))
+                else:
+                    print(f"[VALIDATION OK] {team_name}: Roster and depth chart complete.")
 
     def generate_playoff_bracket(self):
         """Create the playoff bracket using tiebreakers from ``tiebreakers.py``."""
-        print("=== DEBUG: Generating playoff bracket ===")
+        if VERBOSE_SIM_OUTPUT:
+            print("=== DEBUG: Generating playoff bracket ===")
 
         def build_tb_manager():
             league_data = [

--- a/gridiron_gm/gridiron_gm_pkg/simulation/utils/college_player_generator.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/utils/college_player_generator.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from gridiron_gm.gridiron_gm_pkg.simulation.entities.player import Player
 from typing import List, Dict, Optional
 import json
+from gridiron_gm import VERBOSE_SIM_OUTPUT
 
 DEFAULT_FIRST_NAMES = ["Jalen", "Michael", "Tyrone", "Devon"]
 DEFAULT_LAST_NAMES = ["Johnson", "Williams", "Brown", "Taylor"]
@@ -22,7 +23,8 @@ def load_data_file(file_path: str, fallback: List[str]) -> List[str]:
         return data
     except Exception as e:
         print(f"[ERROR] Failed loading file {file_path}: {e}")
-        print(f"[DEBUG] Falling back to default data for {file_path}")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Falling back to default data for {file_path}")
         return fallback
 
 def load_enriched_cities(file_path: str, fallback: List[str]) -> List[str]:
@@ -35,7 +37,8 @@ def load_enriched_cities(file_path: str, fallback: List[str]) -> List[str]:
         return list(set(cities))
     except Exception as e:
         print(f"[ERROR] Failed loading enriched cities file {file_path}: {e}")
-        print(f"[DEBUG] Falling back to default cities for {file_path}")
+        if VERBOSE_SIM_OUTPUT:
+            print(f"[DEBUG] Falling back to default cities for {file_path}")
         return fallback
 
 def generate_valid_jersey_number(position):


### PR DESCRIPTION
## Summary
- add a global `VERBOSE_SIM_OUTPUT` flag
- gate team prints and debug messages in `season_manager`
- hide debug prints in `team_data`, `playoff_manager`, `penalty_engine`, and `college_player_generator`
- import the flag where needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841402649988327a7cd1338ccba7fa1