### PR TITLE
fix save path resolution

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/data_loader.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/data_loader.py
@@ -1,10 +1,11 @@
 import os
 import json
+from pathlib import Path
 
 def load_schedule_files(save_name, calendar=None):
-    base_path = os.path.join("data", "saves", save_name)
-    schedule_path = os.path.join(base_path, "schedule_by_week.json")
-    results_path = os.path.join(base_path, "results_by_week.json")
+    base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name
+    schedule_path = base_path / "schedule_by_week.json"
+    results_path = base_path / "results_by_week.json"
     if os.path.exists(schedule_path):
         with open(schedule_path, "r") as f:
             schedule_by_week = json.load(f)
@@ -18,15 +19,15 @@ def load_schedule_files(save_name, calendar=None):
     return schedule_by_week, results_by_week
 
 def save_results(results_by_week, save_name):
-    results_path = os.path.join("data", "saves", save_name, "results_by_week.json")
-    os.makedirs(os.path.dirname(results_path), exist_ok=True)
+    results_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name / "results_by_week.json"
+    os.makedirs(results_path.parent, exist_ok=True)
     with open(results_path, "w") as f:
         json.dump(results_by_week, f, indent=2)
 
 def save_league_state(league, save_name):
-    base_path = os.path.join("data", "saves", save_name)
+    base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name
     os.makedirs(base_path, exist_ok=True)
-    league_path = os.path.join(base_path, "league.json")
+    league_path = base_path / "league.json"
     with open(league_path, "w") as f:
         if hasattr(league, "to_dict"):
             # Ensures draft_prospects are included if present in league.to_dict()
@@ -38,8 +39,8 @@ def load_league_from_file(save_name, league_class):
     """
     Loads a league object from file, including draft prospects if present.
     """
-    base_path = os.path.join("data", "saves", save_name)
-    league_path = os.path.join(base_path, "league.json")
+    base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name
+    league_path = base_path / "league.json"
     if not os.path.exists(league_path):
         raise FileNotFoundError(f"League file not found: {league_path}")
     with open(league_path, "r") as f:
@@ -52,15 +53,15 @@ def load_league_from_file(save_name, league_class):
     return league
 
 def save_playoff_bracket(playoff_bracket, save_name):
-    base_path = os.path.join("data", "saves", save_name)
-    bracket_path = os.path.join(base_path, "playoff_bracket.json")
+    base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name
+    bracket_path = base_path / "playoff_bracket.json"
     os.makedirs(base_path, exist_ok=True)
     with open(bracket_path, "w") as f:
         json.dump(playoff_bracket, f, indent=2)
 
 def save_playoff_results(playoff_results, save_name):
-    base_path = os.path.join("data", "saves", save_name)
-    results_path = os.path.join(base_path, "playoff_results.json")
+    base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name
+    results_path = base_path / "playoff_results.json"
     os.makedirs(base_path, exist_ok=True)
     with open(results_path, "w") as f:
         json.dump(playoff_results, f, indent=2)

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -3,6 +3,7 @@
 import os
 import json
 import sys
+from pathlib import Path
 from gridiron_gm.gridiron_gm_pkg.simulation.systems.game.standings_manager import (
     StandingsManager,
     update_team_records,
@@ -94,9 +95,9 @@ class SeasonManager:
             self.standings_reset = True
 
     def load_schedule_files(self, save_name):
-        base_path = os.path.join("data", "saves", save_name)
-        schedule_path = os.path.join(base_path, "schedule_by_week.json")
-        results_path = os.path.join(base_path, "results_by_week.json")
+        base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name
+        schedule_path = base_path / "schedule_by_week.json"
+        results_path = base_path / "results_by_week.json"
         if os.path.exists(schedule_path):
             with open(schedule_path, "r") as f:
                 schedule_by_week = json.load(f)
@@ -110,8 +111,8 @@ class SeasonManager:
         return schedule_by_week, results_by_week
 
     def save_results(self):
-        results_path = os.path.join("data", "saves", self.save_name, "results_by_week.json")
-        os.makedirs(os.path.dirname(results_path), exist_ok=True)
+        results_path = Path(__file__).resolve().parents[3] / "data" / "saves" / self.save_name / "results_by_week.json"
+        os.makedirs(results_path.parent, exist_ok=True)
         with open(results_path, "w") as f:
             json.dump(self.results_by_week, f, indent=2)
 
@@ -331,8 +332,8 @@ class SeasonManager:
         }
 
         # Optionally, save the updated schedule
-        base_path = os.path.join("data", "saves", self.save_name)
-        schedule_path = os.path.join(base_path, "schedule_by_week.json")
+        base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / self.save_name
+        schedule_path = base_path / "schedule_by_week.json"
         with open(schedule_path, "w") as f:
             json.dump(self.schedule_by_week, f, indent=2)
 
@@ -479,9 +480,9 @@ class SeasonManager:
         """
         Saves the entire league dictionary (teams + future keys) to JSON.
         """
-        base_path = os.path.join("data", "saves", self.save_name)
+        base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / self.save_name
         os.makedirs(base_path, exist_ok=True)
-        league_path = os.path.join(base_path, "league.json")
+        league_path = base_path / "league.json"
 
         with open(league_path, "w") as f:
             if hasattr(self.league, "to_dict"):

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/standings_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/standings_manager.py
@@ -1,5 +1,6 @@
 import os
 import json
+from pathlib import Path
 
 def update_team_records(home_team, away_team, home_score, away_score):
     """
@@ -108,7 +109,8 @@ class StandingsManager:
 
     def get_standings_path(self):
         year = self.calendar.current_year
-        return f"data/saves/{self.save_name}/standings_{year}.json"
+        base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / self.save_name
+        return str(base_path / f"standings_{year}.json")
 
     def load_standings(self):
         path = self.get_standings_path()
@@ -339,7 +341,8 @@ class StandingsManager:
         return grouped
 
     def load_playoff_seed_map(self, year, save_name="test_league"):
-        bracket_path = f"data/saves/{save_name}/playoffs/playoff_bracket_{year}.json"
+        base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name / "playoffs"
+        bracket_path = base_path / f"playoff_bracket_{year}.json"
         if not os.path.exists(bracket_path):
             self.seed_alias_map = {}
             return


### PR DESCRIPTION
## Summary
- resolve save data paths relative to package root using `pathlib.Path`
- update schedule, standings, and league save helpers accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841417d43f083278238b24eac2f5a5a