### PR TITLE
Add scouted potential reevaluation system

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
@@ -72,6 +72,16 @@ class Player:
         self.career_stats = {}
         self.stats_by_year = {}
 
+        # --- Scouting related fields
+        # hidden_caps: the true ceiling for each attribute (not visible to the user)
+        # scouted_potential: what scouts currently believe the ceiling to be
+        # last_attribute_values: last recorded attribute values for year-over-year comparison
+        # no_growth_years: consecutive years with no growth for an attribute
+        self.hidden_caps = {}
+        self.scouted_potential = {}
+        self.last_attribute_values = {}
+        self.no_growth_years = {}
+
     def add_trait(self, category, trait):
         if category in self.traits:
             self.traits[category].append(trait)
@@ -173,7 +183,11 @@ class Player:
             "rookie_year": self.rookie_year,
             "drafted_by": self.drafted_by,
             "draft_round": self.draft_round,
-            "draft_pick": self.draft_pick
+            "draft_pick": self.draft_pick,
+            "hidden_caps": self.hidden_caps,
+            "scouted_potential": self.scouted_potential,
+            "last_attribute_values": self.last_attribute_values,
+            "no_growth_years": self.no_growth_years
         }
 
     @staticmethod
@@ -204,6 +218,10 @@ class Player:
         player.career_stats = data.get("career_stats", {})
         player.on_injured_reserve = data.get("on_injured_reserve", False)
         player.is_injured = data.get("is_injured", False)
+        player.hidden_caps = data.get("hidden_caps", {})
+        player.scouted_potential = data.get("scouted_potential", {})
+        player.last_attribute_values = data.get("last_attribute_values", {})
+        player.no_growth_years = data.get("no_growth_years", {})
         return player
 
 def ensure_player_objects(team):

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/scouted_potential_reducer.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/scouted_potential_reducer.py
@@ -1,0 +1,63 @@
+"""Utilities for updating scouted potential for a player's attributes."""
+
+from typing import Dict, Any
+
+
+def reevaluate_scouted_potential(player: Any, current_attributes: Dict[str, int]) -> Dict[str, int]:
+    """Re-evaluate scouted potential values for a player's attributes.
+
+    This routine adjusts the *scouted* ceiling for each attribute based on the
+    player's recent development. If an attribute has not improved for two or
+    more seasons, scouts begin to doubt the upside and the scouted potential is
+    reduced slightly. A strong season can partially restore some of that lost
+    faith.
+
+    Parameters
+    ----------
+    player : Any
+        Player object which is expected to contain ``hidden_caps`` and
+        ``scouted_potential`` dictionaries.
+    current_attributes : dict
+        Mapping of attribute names to the player's current ratings.
+
+    Returns
+    -------
+    dict
+        Updated scouted potential values for each attribute.
+    """
+
+    # Ensure required containers exist on the player
+    for field in ("hidden_caps", "scouted_potential", "last_attribute_values", "no_growth_years"):
+        if not hasattr(player, field):
+            setattr(player, field, {})
+
+    strong_season = getattr(player, "strong_season", False)
+
+    updated = {}
+    for attr, value in current_attributes.items():
+        hidden_cap = getattr(player, "hidden_caps", {}).get(attr, value)
+        scouted = getattr(player, "scouted_potential", {}).get(attr, hidden_cap)
+
+        # Track development over time
+        last_val = player.last_attribute_values.get(attr, value)
+        if value > last_val:
+            player.no_growth_years[attr] = 0
+        else:
+            player.no_growth_years[attr] = player.no_growth_years.get(attr, 0) + 1
+        player.last_attribute_values[attr] = value
+
+        # If stagnant for two or more seasons, reduce perceived potential
+        if player.no_growth_years[attr] >= 2 and scouted > value:
+            scouted -= 1
+
+        # Never let scouted potential drop below current ability
+        scouted = max(value, scouted)
+
+        # Optionally regain some lost potential after a strong season
+        if strong_season and scouted < hidden_cap:
+            scouted = min(hidden_cap, scouted + 1)
+
+        player.scouted_potential[attr] = scouted
+        updated[attr] = scouted
+
+    return updated


### PR DESCRIPTION
## Summary
- add data containers for scouting perception to Player
- persist scouted potential related fields in to_dict/from_dict
- create `scouted_potential_reducer` to adjust per-attribute scouted potential

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841eb929260832787f841d598672111