### PR TITLE
Add weekly growth unit test

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/tests/test_player_weekly_growth.py
+++ b/gridiron_gm/gridiron_gm_pkg/tests/test_player_weekly_growth.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.player_weekly_growth import apply_weekly_growth
+
+class DummyAttributes:
+    def __init__(self):
+        self.core = {"awareness": 70}
+        self.position_specific = {"route_running": 72}
+
+class DummyPlayer:
+    def __init__(self):
+        self.attributes = DummyAttributes()
+        self.fatigue = 0.1
+        self.snaps = 60
+
+
+def test_apply_weekly_growth_small_deltas(monkeypatch):
+    # Remove randomness for deterministic test results
+    monkeypatch.setattr(
+        "gridiron_gm.gridiron_gm_pkg.simulation.systems.player.player_weekly_growth.random.uniform",
+        lambda a, b: 1.0,
+    )
+
+    player = DummyPlayer()
+    context = {"snaps": 60}
+
+    deltas = apply_weekly_growth(player, context)
+
+    assert set(deltas.keys()) == {"awareness", "route_running"}
+    assert all(isinstance(v, float) for v in deltas.values())
+    assert all(0 < v <= 0.25 for v in deltas.values())


### PR DESCRIPTION
## Summary
- add test verifying apply_weekly_growth returns small deterministic deltas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ed7a9f10832799a1b57542df7df4