### PR TITLE
Implement league record keeping utilities

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/gui/main_menu.py
+++ b/gridiron_gm/gridiron_gm_pkg/gui/main_menu.py
@@ -101,6 +101,21 @@ def start_new_game():
         "season_year": 2025,
         "team_name": team_name,
         "teams": [],
+        "league_records": {
+            "players": {
+                "single_game": {},
+                "single_season": {},
+                "career": {}
+            },
+            "teams": {
+                "single_game": {},
+                "single_season": {},
+                "career": {}
+            },
+            "leaderboards": {
+                "current_season": {}
+            }
+        },
         "schedule": {},
         "calendar": {
             "current_date": "2025-08-01",

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/save_system.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/core/save_system.py
@@ -39,7 +39,28 @@ class SaveSystem:
         return save_data.get("game_world", None)
 
     def start_new_game(self, template=None):
-        return template if template else {"year": 2025, "teams": [], "players": []}
+        if template:
+            return template
+        return {
+            "year": 2025,
+            "teams": [],
+            "players": [],
+            "league_records": {
+                "players": {
+                    "single_game": {},
+                    "single_season": {},
+                    "career": {}
+                },
+                "teams": {
+                    "single_game": {},
+                    "single_season": {},
+                    "career": {}
+                },
+                "leaderboards": {
+                    "current_season": {}
+                }
+            }
+        }
 
     # Save and Load GM Profile
     def save_gm_profile(self, gm_profile):

--- a/gridiron_gm/gridiron_gm_pkg/stats/__init__.py
+++ b/gridiron_gm/gridiron_gm_pkg/stats/__init__.py
@@ -1,1 +1,11 @@
+from .player_stat_manager import update_player_stats, update_career_stats
+from .record_book import (
+    update_single_game_record,
+    update_single_season_record,
+    update_career_record,
+    update_leaderboard,
+    update_team_single_game_record,
+    update_team_single_season_record,
+    update_team_career_record,
+)
 

--- a/gridiron_gm/gridiron_gm_pkg/stats/record_book.py
+++ b/gridiron_gm/gridiron_gm_pkg/stats/record_book.py
@@ -1,0 +1,79 @@
+"""Utilities for tracking league records and leaderboards."""
+from __future__ import annotations
+from typing import Dict, Any, List, Tuple
+
+
+def _ensure_structure(game_world: Dict[str, Any]) -> Dict[str, Any]:
+    """Ensure the league_records structure exists and return it."""
+    league_records = game_world.setdefault("league_records", {})
+    players = league_records.setdefault("players", {})
+    players.setdefault("single_game", {})
+    players.setdefault("single_season", {})
+    players.setdefault("career", {})
+
+    teams = league_records.setdefault("teams", {})
+    teams.setdefault("single_game", {})
+    teams.setdefault("single_season", {})
+    teams.setdefault("career", {})
+
+    leaderboards = league_records.setdefault("leaderboards", {})
+    leaderboards.setdefault("current_season", {})
+    return league_records
+
+
+def _update_record(store: Dict[str, Dict[str, Any]], stat: str, entity_key: str, entity_id: str, value: int | float) -> None:
+    """Helper to update a record if ``value`` exceeds the current record."""
+    record = store.get(stat)
+    if not record or value > record.get("value", 0):
+        store[stat] = {entity_key: entity_id, "value": value}
+
+
+# ----- Player Records -----
+
+def update_single_game_record(game_world: Dict[str, Any], player_id: str, stat_name: str, value: int | float) -> None:
+    records = _ensure_structure(game_world)["players"]["single_game"]
+    _update_record(records, stat_name, "player_id", player_id, value)
+
+
+def update_single_season_record(game_world: Dict[str, Any], player_id: str, stat_name: str, value: int | float) -> None:
+    records = _ensure_structure(game_world)["players"]["single_season"]
+    _update_record(records, stat_name, "player_id", player_id, value)
+
+
+def update_career_record(game_world: Dict[str, Any], player_id: str, stat_name: str, value: int | float) -> None:
+    records = _ensure_structure(game_world)["players"]["career"]
+    _update_record(records, stat_name, "player_id", player_id, value)
+
+
+def update_leaderboard(game_world: Dict[str, Any], stat_name: str, player_id: str, value: int | float, limit: int = 10) -> None:
+    boards = _ensure_structure(game_world)["leaderboards"]["current_season"]
+    board: List[Tuple[str, int | float]] = boards.setdefault(stat_name, [])
+
+    for i, (pid, val) in enumerate(board):
+        if pid == player_id:
+            if value > val:
+                board[i] = (player_id, value)
+            break
+    else:
+        board.append((player_id, value))
+
+    board.sort(key=lambda x: x[1], reverse=True)
+    del board[limit:]
+
+
+# ----- Team Records -----
+
+def update_team_single_game_record(game_world: Dict[str, Any], team_id: str, stat_name: str, value: int | float) -> None:
+    records = _ensure_structure(game_world)["teams"]["single_game"]
+    _update_record(records, stat_name, "team_id", team_id, value)
+
+
+def update_team_single_season_record(game_world: Dict[str, Any], team_id: str, stat_name: str, value: int | float) -> None:
+    records = _ensure_structure(game_world)["teams"]["single_season"]
+    _update_record(records, stat_name, "team_id", team_id, value)
+
+
+def update_team_career_record(game_world: Dict[str, Any], team_id: str, stat_name: str, value: int | float) -> None:
+    records = _ensure_structure(game_world)["teams"]["career"]
+    _update_record(records, stat_name, "team_id", team_id, value)
+

--- a/tests/test_record_book.py
+++ b/tests/test_record_book.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm.gridiron_gm_pkg.stats.record_book import (
+    update_single_game_record,
+    update_single_season_record,
+    update_career_record,
+    update_leaderboard,
+    update_team_single_game_record,
+    update_team_single_season_record,
+    update_team_career_record,
+)
+
+
+def make_game_world():
+    return {
+        "league_records": {
+            "players": {"single_game": {}, "single_season": {}, "career": {}},
+            "teams": {"single_game": {}, "single_season": {}, "career": {}},
+            "leaderboards": {"current_season": {}}
+        }
+    }
+
+
+def test_player_single_game_record_updates():
+    gw = make_game_world()
+    update_single_game_record(gw, "p1", "passing_yards", 300)
+    update_single_game_record(gw, "p2", "passing_yards", 250)
+    assert gw["league_records"]["players"]["single_game"]["passing_yards"]["player_id"] == "p1"
+    update_single_game_record(gw, "p2", "passing_yards", 350)
+    rec = gw["league_records"]["players"]["single_game"]["passing_yards"]
+    assert rec == {"player_id": "p2", "value": 350}
+
+
+def test_leaderboard_tracks_top_ten():
+    gw = make_game_world()
+    for i in range(12):
+        update_leaderboard(gw, "passing_yards", f"p{i}", i * 100)
+    board = gw["league_records"]["leaderboards"]["current_season"]["passing_yards"]
+    assert len(board) == 10
+    assert board[0] == ("p11", 1100)
+    assert all(board[i][1] >= board[i+1][1] for i in range(len(board)-1))
+
+
+def test_team_records_update():
+    gw = make_game_world()
+    update_team_single_game_record(gw, "t1", "points_scored", 40)
+    update_team_single_game_record(gw, "t2", "points_scored", 35)
+    assert gw["league_records"]["teams"]["single_game"]["points_scored"]["team_id"] == "t1"
+    update_team_single_game_record(gw, "t2", "points_scored", 45)
+    rec = gw["league_records"]["teams"]["single_game"]["points_scored"]
+    assert rec == {"team_id": "t2", "value": 45}


### PR DESCRIPTION
## Summary
- track league records and leaderboards
- expose new record helpers in stats package
- add league_records key when starting new games
- include league_records when SaveSystem starts a game
- test record book utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fcaacfc483279eaa98b3b86f50af