### PR TITLE
Code cleanup and fix imports

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/gui/in_game_menu.py
+++ b/gridiron_gm/gridiron_gm_pkg/gui/in_game_menu.py
@@ -1,7 +1,5 @@
 # ui/in_game_menu.py
 
-from gridiron_gm.gridiron_gm_pkg.engine.phase_manager import advance_game_day, advance_game_week, phase_manager
-from gridiron_gm.gridiron_gm_pkg.engine.core.game_simulator import simulate_week
 from gridiron_gm.gridiron_gm_pkg.gui.roster_screen import roster_screen
 
 def in_game_menu(game_world, gm_profile):
@@ -105,3 +103,18 @@ def view_gm_profile(gm_profile):
     print(f"Hair Color: {appearance.get('hair_color', 'Unknown')}")
     print(f"Skin Tone: {appearance.get('skin_tone', 'Unknown')}")
     print(f"Height: {appearance.get('height', 'Unknown')} inches")
+
+# --- Simulation Stubs ---
+def advance_game_week(game_world):
+    """Placeholder for advancing a week in the game calendar."""
+    print("\nAdvancing one week... (Not implemented)")
+
+
+def advance_game_day(game_world):
+    """Placeholder for advancing a single day."""
+    print("\nAdvancing one day... (Not implemented)")
+
+
+def phase_manager(game_world):
+    """Placeholder for updating game phase."""
+    print("\nUpdating game phase... (Not implemented)")

--- a/gridiron_gm/gridiron_gm_pkg/gui/main_menu.py
+++ b/gridiron_gm/gridiron_gm_pkg/gui/main_menu.py
@@ -12,16 +12,9 @@ from gridiron_gm.gridiron_gm_pkg.simulation.utils.roster_generator import Roster
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-TEAM_LIST = [
-    "Chicago Cyclones", "Dallas Outlaws", "Miami Tritons", "New York Empire",
-    "San Francisco Surge", "Tennessee Renegades", "Las Vegas Vipers", "Atlanta Flight",
-    "Boston Redcoats", "Houston Stampede", "Los Angeles Paladins", "Philadelphia Liberty",
-    "Phoenix Inferno", "Detroit Mechanics", "Seattle Eclipse", "Denver Bighorns",
-    "Cleveland Vanguards", "Orlando Stingrays", "Minnesota Mammoths", "Baltimore Knights",
-    "New Orleans Specters", "Indianapolis Racers", "Cincinnati Sabers", "Kansas City Kings",
-    "Charlotte Stingers", "Tampa Bay Sharks", "Pittsburgh Ironmen", "Washington Generals",
-    "Green Bay Lumberjacks", "Buffalo Blizzard", "San Diego Armada", "Portland Pioneers"
-]
+TEAM_LIST_PATH = os.path.join(BASE_DIR, "..", "config", "teams.json")
+with open(TEAM_LIST_PATH, "r") as f:
+    TEAM_LIST = json.load(f)
 
 def main_menu():
     while True:
@@ -68,14 +61,14 @@ def start_new_game():
 
     print("\nSelect Your Team:")
     for idx, team in enumerate(TEAM_LIST, 1):
-        print(f"[{idx}] {team}")
+        print(f"[{idx}] {team['city']} {team['name']}")
 
     while True:
         try:
             team_choice = int(input("Enter team number (1-32): "))
             if 1 <= team_choice <= len(TEAM_LIST):
                 team_entry = TEAM_LIST[team_choice - 1]
-                team_name = team_entry["team_name"]
+                team_name = team_entry["name"]
                 team_city = team_entry["city"]
 
                 break

--- a/gridiron_gm/gridiron_gm_pkg/main.py
+++ b/gridiron_gm/gridiron_gm_pkg/main.py
@@ -1,7 +1,6 @@
+"""Entry point for launching the text-based interface."""
+
 from gridiron_gm.gridiron_gm_pkg.gui.main_menu import main_menu
-from gridiron_gm.gridiron_gm_pkg.engine.core.calendar import Calendar
-from gridiron_gm.gridiron_gm_pkg.engine.simulation.sim_controller import simulate_week
-from gridiron_gm.gridiron_gm_pkg.engine.core.league_manager import LeagueManager  # or wherever your League class is
 
 if __name__ == "__main__":
     main_menu()

--- a/gridiron_gm/gridiron_gm_pkg/simulation/AI/cpu_trade_offers.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/AI/cpu_trade_offers.py
@@ -1,11 +1,12 @@
 
-# engine/trade/cpu_trade_offers.py
+"""AI utilities for generating CPU-initiated trade offers."""
 
 from gridiron_gm.gridiron_gm_pkg.engine.trade.trade_value import evaluate_player_value, calculate_pick_value
 from gridiron_gm.gridiron_gm_pkg.engine.trade.trade_decision import compute_total_trade_value, should_accept_trade
 import random
 
 def generate_cpu_trade_offers(teams, week_number):
+    """Generate trade offers between CPU-controlled teams."""
     trade_offers = []
 
     for seller in teams:
@@ -31,7 +32,6 @@ def generate_cpu_trade_offers(teams, week_number):
         buyer = buyer_candidates[0]
         pick_round = pick_round_for_value(player_value)
         pick_label = format_pick_round(pick_round)
-        buyer_pick_value = calculate_pick_value(pick_round, buyer, is_future=False)
 
         offer = {
             "from_team": seller.team_name,
@@ -59,6 +59,7 @@ def generate_cpu_trade_offers(teams, week_number):
     return trade_offers
 
 def format_pick_round(round_num):
+    """Return a human-readable string for a draft pick round."""
     if round_num == 1:
         return "1st Round Pick"
     elif round_num == 2:
@@ -69,6 +70,7 @@ def format_pick_round(round_num):
         return f"{round_num}th Round Pick"
 
 def find_best_trade_partners(player, seller, all_teams):
+    """Return potential trade partners sorted by positional need."""
     buyers = [
         t for t in all_teams if t != seller and not getattr(t, "rebuild_mode", True)
     ]
@@ -83,6 +85,7 @@ def find_best_trade_partners(player, seller, all_teams):
     return [entry[0] for entry in scored_buyers]
 
 def evaluate_team_need(team, position):
+    """Simple heuristic to rank how badly a team needs a position."""
     position_players = [p for p in team.players if p.position == position]
     if not position_players:
         return 10
@@ -93,6 +96,7 @@ def evaluate_team_need(team, position):
     return 0
 
 def pick_round_for_value(value):
+    """Determine draft round compensation based on a player's value."""
     if value >= 1000:
         return 1
     elif value >= 400:

--- a/gridiron_gm/gridiron_gm_pkg/simulation/engine/__init__.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/engine/__init__.py
@@ -1,0 +1,9 @@
+"""Core simulation engine package for Gridiron GM."""
+
+__all__ = [
+    "game_engine",
+    "contract_engine",
+    "penalty_engine",
+    "play_time_model",
+    "stat_utils",
+]

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -61,7 +61,7 @@ class SeasonManager:
 
         self.team_map = self.id_to_team  # For compatibility, but always use team.id as key
 
-        self.schedule_by_week, self.results_by_week = self.load_schedule_files(save_name)
+        self.schedule_by_week, self.results_by_week = load_schedule_files(save_name)
         self.last_scheduled_day_for_week = {
             str(week): (
                 max(
@@ -97,27 +97,6 @@ class SeasonManager:
             self.standings_manager.save_standings()
             self.standings_reset = True
 
-    def load_schedule_files(self, save_name):
-        base_path = Path(__file__).resolve().parents[3] / "data" / "saves" / save_name
-        schedule_path = base_path / "schedule_by_week.json"
-        results_path = base_path / "results_by_week.json"
-        if os.path.exists(schedule_path):
-            with open(schedule_path, "r") as f:
-                schedule_by_week = json.load(f)
-        else:
-            schedule_by_week = {}
-        if os.path.exists(results_path):
-            with open(results_path, "r") as f:
-                results_by_week = json.load(f)
-        else:
-            results_by_week = {}
-        return schedule_by_week, results_by_week
-
-    def save_results(self):
-        results_path = Path(__file__).resolve().parents[3] / "data" / "saves" / self.save_name / "results_by_week.json"
-        os.makedirs(results_path.parent, exist_ok=True)
-        with open(results_path, "w") as f:
-            json.dump(self.results_by_week, f, indent=2)
 
     def ensure_valid_depth_charts(self):
         for team in self.league.teams:
@@ -260,7 +239,7 @@ class SeasonManager:
 
         # End of day: set time to 23:59
         self.calendar.current_time_str = "23:59"
-        self.save_results()
+        save_results(self.results_by_week, self.save_name)
 
     def advance_day(self):
         """Advance the simulation through a single day."""
@@ -566,7 +545,7 @@ class SeasonManager:
         self.playoff_bracket = {}
         self.champion = None
         self.runner_up = None
-        self.schedule_by_week, self.results_by_week = self.load_schedule_files(self.save_name)
+        self.schedule_by_week, self.results_by_week = load_schedule_files(self.save_name)
         self.standings_manager.results_by_week = self.results_by_week
 
     def start_new_season(self):
@@ -577,7 +556,7 @@ class SeasonManager:
         # Validate rosters and depth charts before loading schedule
         self.validate_team_rosters_and_depth_charts()
         # Generate new schedule, reset standings, etc.
-        self.schedule_by_week, self.results_by_week = self.load_schedule_files(self.save_name)
+        self.schedule_by_week, self.results_by_week = load_schedule_files(self.save_name)
         self.standings_manager.results_by_week = self.results_by_week
         self.standings_manager.save_standings()
 

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/roster/depth_chart.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/roster/depth_chart.py
@@ -89,9 +89,3 @@ def generate_depth_chart(team: Any) -> Dict[str, List[Any]]:
 
     return depth_chart
 
-# When generating a depth chart or active lineup:
-# Example team object for demonstration; replace with your actual team object as needed.
-team = {"roster": []}  # Replace with actual team data
-healthy_roster = get_healthy_players(team.get("roster", []))
-depth_chart = generate_depth_chart(healthy_roster)
-# Or, if your sub_manager uses the full roster, pass only healthy players


### PR DESCRIPTION
## Summary
- add engine package `__init__`
- trim example code from `depth_chart`
- remove duplicate schedule persistence methods
- fix broken imports in CLI modules
- read team list from configuration
- add docstrings to CPU trade offer helpers
- stub phase management functions in `in_game_menu`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842810efad08327925e6d8f44d927fd