### PR TITLE
Support career stat aggregation

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
@@ -142,6 +142,42 @@ class Player:
                 self.injuries.clear()
                 self.is_injured = False
 
+    def update_career_stats_from_season(self, year, game_world=None):
+        """Aggregate a season's totals into ``career_stats``.
+
+        Parameters
+        ----------
+        year : int | str
+            The season year to aggregate.
+        game_world : dict | None
+            Optional game world to update career record tracking.
+        """
+        year_key = str(year)
+        data = self.season_stats.get(year_key)
+        if not data or data.get("career_added"):
+            return
+
+        from gridiron_gm.gridiron_gm_pkg.stats.player_stat_manager import (
+            update_career_stats,
+        )
+
+        totals = data.get("season_totals", {})
+        update_career_stats(self, totals)
+        data["career_added"] = True
+
+        if game_world is not None:
+            from gridiron_gm.gridiron_gm_pkg.stats.record_book import (
+                update_career_record,
+                update_career_leaderboard,
+            )
+
+            for stat, val in totals.items():
+                if stat == "snap_counts" or not isinstance(val, (int, float)):
+                    continue
+                current = self.career_stats.get(stat, 0)
+                update_career_record(game_world, self.id, stat, current)
+                update_career_leaderboard(game_world, stat, self.id, current)
+
     def update_player_stats(self, stat_type, value):
         if stat_type in self.career_stats:
             self.career_stats[stat_type] += value

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -488,7 +488,9 @@ class SeasonManager:
                 if isinstance(raw_stats, dict) and year_key in raw_stats:
                     year_data = raw_stats[year_key]
                     season_stats = year_data.get("season_totals", {})
-                    if not year_data.get("career_added"):
+                    if hasattr(player, "update_career_stats_from_season"):
+                        player.update_career_stats_from_season(year_key, getattr(self, "game_world", None))
+                    elif not year_data.get("career_added"):
                         from gridiron_gm.gridiron_gm_pkg.stats.player_stat_manager import update_career_stats
                         update_career_stats(player, season_stats)
                         year_data["career_added"] = True

--- a/gridiron_gm/gridiron_gm_pkg/stats/record_book.py
+++ b/gridiron_gm/gridiron_gm_pkg/stats/record_book.py
@@ -18,6 +18,7 @@ def _ensure_structure(game_world: Dict[str, Any]) -> Dict[str, Any]:
 
     leaderboards = league_records.setdefault("leaderboards", {})
     leaderboards.setdefault("current_season", {})
+    leaderboards.setdefault("career", {})
     return league_records
 
 
@@ -47,6 +48,22 @@ def update_career_record(game_world: Dict[str, Any], player_id: str, stat_name: 
 
 def update_leaderboard(game_world: Dict[str, Any], stat_name: str, player_id: str, value: int | float, limit: int = 10) -> None:
     boards = _ensure_structure(game_world)["leaderboards"]["current_season"]
+    board: List[Tuple[str, int | float]] = boards.setdefault(stat_name, [])
+
+    for i, (pid, val) in enumerate(board):
+        if pid == player_id:
+            if value > val:
+                board[i] = (player_id, value)
+            break
+    else:
+        board.append((player_id, value))
+
+    board.sort(key=lambda x: x[1], reverse=True)
+    del board[limit:]
+
+
+def update_career_leaderboard(game_world: Dict[str, Any], stat_name: str, player_id: str, value: int | float, limit: int = 10) -> None:
+    boards = _ensure_structure(game_world)["leaderboards"]["career"]
     board: List[Tuple[str, int | float]] = boards.setdefault(stat_name, [])
 
     for i, (pid, val) in enumerate(board):

--- a/tests/test_career_stats.py
+++ b/tests/test_career_stats.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm.gridiron_gm_pkg.simulation.entities.player import Player
+
+
+def make_game_world():
+    return {
+        "league_records": {
+            "players": {"single_game": {}, "single_season": {}, "career": {}},
+            "teams": {"single_game": {}, "single_season": {}, "career": {}},
+            "leaderboards": {"current_season": {}, "career": {}}
+        }
+    }
+
+
+def test_career_stats_aggregation_and_records():
+    gw = make_game_world()
+    p = Player("Test QB", "QB", 25, "2000-01-01", "U", "USA", 1, 80)
+    p.season_stats = {
+        "2025": {"season_totals": {"passing_yards": 4000, "sacks": 30}}
+    }
+    p.update_career_stats_from_season("2025", gw)
+
+    assert p.career_stats["passing_yards"] == 4000
+    assert p.season_stats["2025"]["career_added"] is True
+
+    # call again to ensure no duplication
+    p.update_career_stats_from_season("2025", gw)
+    assert p.career_stats["passing_yards"] == 4000
+
+    # next season
+    p.season_stats["2026"] = {"season_totals": {"passing_yards": 3500, "sacks": 25}}
+    p.update_career_stats_from_season("2026", gw)
+    assert p.career_stats["passing_yards"] == 7500
+
+    lb = gw["league_records"]["leaderboards"]["career"]["passing_yards"]
+    assert lb[0][0] == p.id and lb[0][1] == 7500
+


### PR DESCRIPTION
## Summary
- add a Player.update_career_stats_from_season helper
- aggregate career stats when applying season progression
- track career leaderboards in `record_book`
- tests for career stat aggregation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428b8114a48327a4929d76cacd27bf