### PR TITLE
Support career stat aggregation

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -488,7 +488,9 @@ class SeasonManager:
                 if isinstance(raw_stats, dict) and year_key in raw_stats:
                     year_data = raw_stats[year_key]
                     season_stats = year_data.get("season_totals", {})
-                    if not year_data.get("career_added"):
+                    if hasattr(player, "update_career_stats_from_season"):
+                        player.update_career_stats_from_season(year_key, getattr(self, "game_world", None))
+                    elif not year_data.get("career_added"):
                         from gridiron_gm.gridiron_gm_pkg.stats.player_stat_manager import update_career_stats
                         update_career_stats(player, season_stats)
                         year_data["career_added"] = True

--- a/gridiron_gm/gridiron_gm_pkg/stats/__init__.py
+++ b/gridiron_gm/gridiron_gm_pkg/stats/__init__.py
@@ -8,4 +8,5 @@ from .record_book import (
     update_team_single_season_record,
     update_team_career_record,
 )
+from .milestone_definitions import MILESTONES
 

--- a/gridiron_gm/gridiron_gm_pkg/stats/milestone_definitions.py
+++ b/gridiron_gm/gridiron_gm_pkg/stats/milestone_definitions.py
@@ -1,0 +1,11 @@
+"""Common milestone definitions for player career stats."""
+
+MILESTONES = {
+    "passing_yards": [10000, 20000, 30000, 40000, 50000],
+    "rushing_yards": [1000, 5000, 10000, 15000],
+    "receiving_yards": [1000, 5000, 10000],
+    "passing_touchdowns": [100, 200, 300],
+    "rushing_touchdowns": [50, 100],
+    "receiving_touchdowns": [50, 100],
+    "sacks": [25, 50, 100],
+}

--- a/gridiron_gm/gridiron_gm_pkg/stats/record_book.py
+++ b/gridiron_gm/gridiron_gm_pkg/stats/record_book.py
@@ -18,6 +18,7 @@ def _ensure_structure(game_world: Dict[str, Any]) -> Dict[str, Any]:
 
     leaderboards = league_records.setdefault("leaderboards", {})
     leaderboards.setdefault("current_season", {})
+    leaderboards.setdefault("career", {})
     return league_records
 
 
@@ -47,6 +48,22 @@ def update_career_record(game_world: Dict[str, Any], player_id: str, stat_name: 
 
 def update_leaderboard(game_world: Dict[str, Any], stat_name: str, player_id: str, value: int | float, limit: int = 10) -> None:
     boards = _ensure_structure(game_world)["leaderboards"]["current_season"]
+    board: List[Tuple[str, int | float]] = boards.setdefault(stat_name, [])
+
+    for i, (pid, val) in enumerate(board):
+        if pid == player_id:
+            if value > val:
+                board[i] = (player_id, value)
+            break
+    else:
+        board.append((player_id, value))
+
+    board.sort(key=lambda x: x[1], reverse=True)
+    del board[limit:]
+
+
+def update_career_leaderboard(game_world: Dict[str, Any], stat_name: str, player_id: str, value: int | float, limit: int = 10) -> None:
+    boards = _ensure_structure(game_world)["leaderboards"]["career"]
     board: List[Tuple[str, int | float]] = boards.setdefault(stat_name, [])
 
     for i, (pid, val) in enumerate(board):

--- a/tests/test_career_stats.py
+++ b/tests/test_career_stats.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm.gridiron_gm_pkg.simulation.entities.player import Player
+
+
+def make_game_world():
+    return {
+        "league_records": {
+            "players": {"single_game": {}, "single_season": {}, "career": {}},
+            "teams": {"single_game": {}, "single_season": {}, "career": {}},
+            "leaderboards": {"current_season": {}, "career": {}}
+        }
+    }
+
+
+def test_career_stats_aggregation_and_records():
+    gw = make_game_world()
+    p = Player("Test QB", "QB", 25, "2000-01-01", "U", "USA", 1, 80)
+    p.season_stats = {
+        "2025": {"season_totals": {"passing_yards": 4000, "sacks": 30}}
+    }
+    p.update_career_stats_from_season("2025", gw)
+
+    assert p.career_stats["passing_yards"] == 4000
+    assert p.season_stats["2025"]["career_added"] is True
+
+    # call again to ensure no duplication
+    p.update_career_stats_from_season("2025", gw)
+    assert p.career_stats["passing_yards"] == 4000
+
+    # next season
+    p.season_stats["2026"] = {"season_totals": {"passing_yards": 3500, "sacks": 25}}
+    p.update_career_stats_from_season("2026", gw)
+    assert p.career_stats["passing_yards"] == 7500
+
+    lb = gw["league_records"]["leaderboards"]["career"]["passing_yards"]
+    assert lb[0][0] == p.id and lb[0][1] == 7500
+
+
+def test_career_milestones_once():
+    p = Player("Milestone QB", "QB", 30, "1995-01-01", "U", "USA", 2, 80)
+    p.season_stats = {
+        "2025": {"season_totals": {"passing_yards": 50001}}
+    }
+
+    new = p.update_career_stats_from_season("2025")
+    expected = {
+        "passing_yards_10000",
+        "passing_yards_20000",
+        "passing_yards_30000",
+        "passing_yards_40000",
+        "passing_yards_50000",
+    }
+    assert set(new) == expected
+    assert p.milestones_hit == expected
+
+    # repeat should yield no duplicates
+    assert p.update_career_stats_from_season("2025") == []
+    assert p.milestones_hit == expected
+
+    # another season with small total shouldn't add milestones
+    p.season_stats["2026"] = {"season_totals": {"passing_yards": 10}}
+    assert p.update_career_stats_from_season("2026") == []
+    assert p.milestones_hit == expected
+


### PR DESCRIPTION
## Summary
- add a Player.update_career_stats_from_season helper
- aggregate career stats when applying season progression
- track career leaderboards in `record_book`
- track milestone achievements for career totals
- tests for career stat aggregation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68428b8114a48327a4929d76cacd27bf