### PR TITLE
Implement weekly training growth system

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -32,6 +32,7 @@ from gridiron_gm.gridiron_gm_pkg.simulation.systems.game.daily_manager import Da
 from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.player_season_progression import (
     evaluate_player_season_progression,
 )
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.weekly_training import apply_weekly_training
 
 
 try:
@@ -282,6 +283,19 @@ class SeasonManager:
                         # Optionally clear injury list or log recovery
                         if hasattr(player, "injuries"):
                             player.injuries.clear()
+
+                # Weekly practice training gains
+                apply_weekly_training(
+                    player,
+                    {
+                        "team": team,
+                        "roster": getattr(team, "roster", []),
+                        "practice_squad": getattr(team, "practice_squad", None),
+                        "coach_quality": getattr(team, "coach_quality", getattr(team, "training_quality", 1.0)),
+                        "week_number": just_ended_week,
+                    },
+                )
+
             # Call fatigue accumulation hook (empty list for heavy_usage_players for now)
             accumulate_season_fatigue_for_team(team, [])
         # Persist standings at the end of the week as well

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/weekly_training.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/weekly_training.py
@@ -1,0 +1,103 @@
+"""Weekly practice attribute growth system."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, Iterable
+
+# Attributes considered physical for slower capped growth
+PHYSICAL_ATTRIBUTES = {
+    "speed",
+    "strength",
+    "acceleration",
+    "agility",
+    "jumping",
+    "throw_power",
+}
+
+# Map of valid training focus keywords to attributes that should grow
+FOCUS_MAP = {
+    "throwing": ["throw_power", "accuracy"],
+    "route running": ["route_running", "awareness"],
+    "awareness": ["awareness"],
+    "strength": ["strength"],
+    "speed": ["speed"],
+}
+
+
+def _get_attr_container(player: Any, attr: str) -> tuple[Dict[str, float], str] | tuple[None, None]:
+    """Return attribute dict and section name for the given attribute."""
+    attrs = getattr(player, "attributes", None)
+    if attrs is None:
+        return None, None
+
+    if hasattr(attrs, "core") and attr in getattr(attrs, "core", {}):
+        return attrs.core, "core"
+    if hasattr(attrs, "position_specific") and attr in getattr(attrs, "position_specific", {}):
+        return attrs.position_specific, "position_specific"
+    return None, None
+
+
+def apply_weekly_training(player: Any, team_context: Any) -> None:
+    """Apply weekly training gains directly to the player's attributes."""
+
+    # Check active/practice squad membership
+    roster = None
+    practice = None
+    if isinstance(team_context, dict):
+        roster = team_context.get("roster") or getattr(team_context.get("team"), "roster", None)
+        practice = team_context.get("practice_squad")
+        quality = team_context.get("coach_quality", team_context.get("training_quality", 1.0))
+        week = team_context.get("week_number")
+    else:
+        roster = getattr(team_context, "roster", getattr(team_context, "players", None))
+        practice = getattr(team_context, "practice_squad", None)
+        quality = getattr(team_context, "coach_quality", getattr(team_context, "training_quality", 1.0))
+        week = getattr(team_context, "current_week", None)
+
+    if roster is not None and player not in roster and (practice is None or player not in practice):
+        return
+
+    if getattr(player, "is_injured", False):
+        return
+
+    focus = getattr(player, "training_focus", None)
+    if not focus:
+        return
+
+    attr_names = FOCUS_MAP.get(str(focus).lower())
+    if not attr_names:
+        return
+
+    # Determine multiplier from coaching quality
+    try:
+        mult = float(quality)
+    except (TypeError, ValueError):
+        mult = 1.0
+    mult = min(1.2, max(0.8, mult))
+
+    # Ensure tracking containers exist
+    if not hasattr(player, "training_log"):
+        player.training_log = {}
+    if not hasattr(player, "_season_physical_growth"):
+        player._season_physical_growth = {}
+
+    for attr in attr_names:
+        container, _ = _get_attr_container(player, attr)
+        if container is None:
+            continue
+
+        if attr in PHYSICAL_ATTRIBUTES:
+            gain = random.uniform(0.1, 0.3) * mult
+            total = player._season_physical_growth.get(attr, 0.0)
+            if total >= 2.0:
+                continue
+            gain = min(gain, 2.0 - total)
+            player._season_physical_growth[attr] = total + gain
+        else:
+            gain = random.uniform(0.1, 0.5) * mult
+
+        container[attr] = round(container.get(attr, 0) + gain, 2)
+
+        if week is not None:
+            player.training_log.setdefault(week, {})[attr] = round(gain, 3)

--- a/gridiron_gm/gridiron_gm_pkg/tests/test_weekly_training.py
+++ b/gridiron_gm/gridiron_gm_pkg/tests/test_weekly_training.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.weekly_training import apply_weekly_training
+
+class DummyAttrs:
+    def __init__(self):
+        self.core = {"accuracy": 60, "throw_power": 60, "awareness": 50, "speed": 80}
+        self.position_specific = {"route_running": 65}
+
+class DummyPlayer:
+    def __init__(self):
+        self.attributes = DummyAttrs()
+        self.training_focus = "throwing"
+        self.is_injured = False
+
+class DummyTeam:
+    def __init__(self, player, quality=1.0):
+        self.roster = [player]
+        self.practice_squad = []
+        self.coach_quality = quality
+        self.current_week = 1
+
+
+def test_training_applies_growth(monkeypatch):
+    player = DummyPlayer()
+    team = DummyTeam(player, quality=1.1)
+
+    monkeypatch.setattr("random.uniform", lambda a, b: b)
+
+    apply_weekly_training(player, team)
+
+    # Accuracy (mental) should grow more than throw_power (physical)
+    assert player.attributes.core["accuracy"] > 60
+    assert player.attributes.core["throw_power"] > 60
+    assert player.attributes.core["accuracy"] - 60 > player.attributes.core["throw_power"] - 60
+
+
+def test_injured_or_no_focus_no_growth(monkeypatch):
+    player = DummyPlayer()
+    team = DummyTeam(player)
+    player.training_focus = None
+
+    monkeypatch.setattr("random.uniform", lambda a, b: b)
+    apply_weekly_training(player, team)
+    assert player.attributes.core["accuracy"] == 60
+
+    player.training_focus = "throwing"
+    player.is_injured = True
+    apply_weekly_training(player, team)
+    assert player.attributes.core["accuracy"] == 60
+
+
+def test_physical_growth_cap(monkeypatch):
+    player = DummyPlayer()
+    player.training_focus = "speed"
+    team = DummyTeam(player)
+
+    monkeypatch.setattr("random.uniform", lambda a, b: b)
+    for _ in range(20):
+        apply_weekly_training(player, team)
+    # cap at +2 total
+    assert round(player.attributes.core["speed"] - 80, 3) <= 2.0
+
+
+def test_coach_multiplier(monkeypatch):
+    player = DummyPlayer()
+    team = DummyTeam(player, quality=1.2)
+
+    monkeypatch.setattr("random.uniform", lambda a, b: b)
+    apply_weekly_training(player, team)
+
+    # mental attribute gain should reflect multiplier 1.2
+    assert round(player.attributes.core["accuracy"] - 60, 2) == round(0.5 * 1.2, 2)


### PR DESCRIPTION
## Summary
- add a weekly training module that applies small weekly attribute gains
- integrate weekly training into `SeasonManager.handle_week_end`
- create tests for the new weekly training logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684318245e1883279330f7f109f57495