### PR TITLE
Add breakout game detection

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/breakout_tracker.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/breakout_tracker.py
@@ -1,0 +1,160 @@
+"""Dynamic breakout game detection and attribute boost system."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, Iterable
+
+# Basic mapping of position to attributes that can be boosted on a breakout
+POSITION_ATTRIBUTES = {
+    "WR": ["catching", "route_running", "release", "agility", "break_tackle"],
+    "RB": ["speed", "agility", "break_tackle", "carrying", "vision"],
+    "QB": ["accuracy", "throw_power", "awareness"],
+    "TE": ["catching", "route_running", "strength"],
+    "DL": ["power_moves", "finesse_moves", "strength"],
+    "LB": ["tackling", "play_recognition", "block_shed"],
+    "CB": ["coverage", "agility", "awareness"],
+}
+
+
+def _get_attr_containers(player: Any) -> tuple[Dict[str, int], Dict[str, int]]:
+    """Return core and position-specific attribute dictionaries."""
+    attrs = getattr(player, "attributes", None)
+    if attrs is None:
+        return {}, {}
+    if isinstance(attrs, dict):
+        core = attrs.get("core", {})
+        pos = attrs.get("position_specific", {})
+    else:
+        core = getattr(attrs, "core", {})
+        pos = getattr(attrs, "position_specific", {})
+    return core, pos
+
+
+def _get_season_data(player: Any, year: str) -> tuple[Dict[str, Any], Dict[str, Any], Dict[int, Dict[str, Any]]]:
+    season = getattr(player, "season_stats", {}).get(year, {})
+    totals = season.get("season_totals", {})
+    logs = season.get("game_logs", {})
+    return season, totals, logs
+
+
+def _prior_games(logs: Dict[int, Dict[str, Any]], week_number: int) -> int:
+    return sum(1 for w in logs if int(w) < week_number)
+
+
+def _value_list(stats_list: Iterable[Dict[str, Any]], stat: str) -> list[int | float]:
+    vals = []
+    for s in stats_list:
+        val = s.get(stat)
+        if isinstance(val, (int, float)):
+            vals.append(val)
+    return vals
+
+
+def check_breakout_game(player: Any, game_stats: Dict[str, int | float], league_context: Dict[str, Any], week_number: int) -> bool:
+    """Detect a breakout game and apply attribute boosts.
+
+    Parameters
+    ----------
+    player : Any
+        Player object with ``overall``, ``dev_arc`` and stat containers.
+    game_stats : dict
+        Stat line from the game to evaluate.
+    league_context : dict
+        Context including at minimum ``current_year`` and optional weekly stats.
+    week_number : int
+        Week number of the game.
+
+    Returns
+    -------
+    bool
+        True if a breakout was detected and applied.
+    """
+    year = str(league_context.get("current_year", ""))
+
+    # Ensure single breakout per season
+    if not hasattr(player, "breakout_log"):
+        player.breakout_log = {}
+    for info in player.breakout_log.values():
+        if info.get("season") == year:
+            return False
+
+    # Do not trigger for established stars
+    overall = getattr(player, "overall", 0)
+    dev_type = getattr(getattr(player, "dev_arc", None), "type", "").lower()
+    if overall >= 80 or dev_type in {"star", "x_factor"}:
+        return False
+
+    # Basic experience/usage check
+    career_snaps = sum(getattr(player, "career_stats", {}).get("snap_counts", {}).values())
+    if career_snaps > 500 or getattr(player, "experience", 0) > 2:
+        return False
+
+    season, totals, logs = _get_season_data(player, year)
+
+    prior_games = _prior_games(logs, week_number)
+    # Determine YTD totals before this game
+    prev_totals: Dict[str, float] = {}
+    for stat, val in game_stats.items():
+        total = totals.get(stat, 0)
+        if week_number in logs:
+            total -= game_stats.get(stat, 0)
+        prev_totals[stat] = max(0.0, float(total))
+
+    def _is_big_jump(stat: str, val: float) -> bool:
+        prev = prev_totals.get(stat, 0.0)
+        avg = prev / max(1, prior_games)
+        return val >= 3 * max(avg, 1)
+
+    breakout = False
+    for stat, val in game_stats.items():
+        if not isinstance(val, (int, float)):
+            continue
+        if _is_big_jump(stat, float(val)):
+            breakout = True
+            break
+
+    # If not a huge jump, see if this stat ranks in top 5% of position this week
+    if not breakout:
+        wk_stats = (
+            league_context.get("weekly_stats", {})
+            .get(week_number, {})
+            .get(getattr(player, "position", ""), [])
+        )
+        for stat, val in game_stats.items():
+            values = _value_list(wk_stats, stat)
+            if not values:
+                continue
+            values.sort(reverse=True)
+            idx = max(0, int(len(values) * 0.05) - 1)
+            if idx < len(values) and val >= values[idx] and val > 0:
+                breakout = True
+                break
+
+    if not breakout:
+        return False
+
+    core, pos = _get_attr_containers(player)
+    possible_attrs = POSITION_ATTRIBUTES.get(getattr(player, "position", ""), list(pos.keys()) or list(core.keys()))
+    if not possible_attrs:
+        return False
+
+    num_attrs = random.randint(1, min(3, len(possible_attrs)))
+    selected = random.sample(possible_attrs, num_attrs)
+
+    boosts: Dict[str, int] = {}
+    for attr in selected:
+        inc = random.randint(1, 5)
+        if attr in pos:
+            pos[attr] = pos.get(attr, 0) + inc
+        else:
+            core[attr] = core.get(attr, 0) + inc
+        boosts[attr] = inc
+
+    player.breakout_log[week_number] = {
+        "season": year,
+        "stats": dict(game_stats),
+        "boosts": boosts,
+    }
+    return True
+

--- a/tests/test_breakout_tracker.py
+++ b/tests/test_breakout_tracker.py
@@ -1,0 +1,93 @@
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm.gridiron_gm_pkg.simulation.entities.player import Player
+from gridiron_gm.gridiron_gm_pkg.stats.player_stat_manager import update_player_stats
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.breakout_tracker import (
+    check_breakout_game,
+)
+
+
+random.seed(1)
+
+
+def make_league_context(year=2025):
+    return {"current_year": year, "weekly_stats": {}}
+
+
+def test_backup_wr_breakout():
+    p = Player("Breakout WR", "WR", 24, "2001-01-01", "U", "USA", 11, 72)
+    p.attributes.position_specific = {"catching": 70, "route_running": 70}
+
+    update_player_stats(p, 1, 2025, {"receiving_yards": 10}, {"offense": 10})
+    update_player_stats(
+        p,
+        3,
+        2025,
+        {"receiving_yards": 120, "receiving_tds": 2, "receptions": 6},
+        {"offense": 60},
+    )
+
+    ctx = make_league_context()
+    result = check_breakout_game(
+        p, {"receiving_yards": 120, "receiving_tds": 2}, ctx, 3
+    )
+
+    assert result is True
+    assert 3 in p.breakout_log
+    boosts = p.breakout_log[3]["boosts"]
+    for attr, inc in boosts.items():
+        if attr in p.attributes.position_specific:
+            assert p.attributes.position_specific[attr] >= 70 + inc
+
+
+def test_star_wr_no_breakout():
+    p = Player("Star WR", "WR", 28, "1997-01-01", "U", "USA", 10, 92)
+    p.dev_arc.type = "x_factor"
+    p.attributes.position_specific = {"catching": 90}
+    update_player_stats(
+        p,
+        3,
+        2025,
+        {"receiving_yards": 120, "receiving_tds": 2},
+        {"offense": 70},
+    )
+
+    ctx = make_league_context()
+    result = check_breakout_game(
+        p, {"receiving_yards": 120, "receiving_tds": 2}, ctx, 3
+    )
+
+    assert result is False
+    assert getattr(p, "breakout_log", {}) == {}
+
+
+def test_low_usage_rb_breakout():
+    p = Player("Backup RB", "RB", 23, "2002-01-01", "U", "USA", 22, 68)
+    p.attributes.position_specific = {"speed": 80, "agility": 78}
+
+    update_player_stats(p, 1, 2025, {"rushing_yards": 30, "rush_attempts": 10}, {"offense": 20})
+    update_player_stats(
+        p,
+        4,
+        2025,
+        {"rushing_yards": 100, "rush_attempts": 15, "rushing_tds": 1},
+        {"offense": 40},
+    )
+
+    ctx = make_league_context()
+    result = check_breakout_game(
+        p, {"rushing_yards": 100, "rushing_tds": 1}, ctx, 4
+    )
+
+    assert result is True
+    assert 4 in p.breakout_log
+    boosts = p.breakout_log[4]["boosts"]
+    assert boosts
+    for attr, inc in boosts.items():
+        if attr in p.attributes.position_specific:
+            assert p.attributes.position_specific[attr] >= 80 - 2 + inc or p.attributes.position_specific[attr] >= 78 + inc
+


### PR DESCRIPTION
## Summary
- implement dynamic breakout game system
- store breakout boosts by week
- test WR and RB breakout scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431acb4104832793d105a56d05497f