### PR TITLE
Add training injury risk

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/config/training_catalog.py
+++ b/gridiron_gm/gridiron_gm_pkg/config/training_catalog.py
@@ -1,0 +1,35 @@
+TRAINING_CATALOG = {
+    "QB Accuracy": {
+        "positions": ["QB"],
+        "attribute_weights": {
+            "throw_accuracy_short": 1.0,
+            "throw_power": 0.5,
+            "awareness": 0.3,
+        },
+        "injury_chance": 0.003,
+    },
+    "WR Footwork": {
+        "positions": ["WR"],
+        "attribute_weights": {
+            "route_running_short": 1.0,
+            "agility": 0.8,
+            "awareness": 0.2,
+        },
+        "injury_chance": 0.004,
+    },
+    "Strength Circuit": {
+        "positions": "ALL",
+        "attribute_weights": {
+            "strength": 1.0,
+            "stamina": 0.5,
+        },
+        "injury_chance": 0.01,
+    },
+    "Film Study": {
+        "positions": "ALL",
+        "attribute_weights": {
+            "awareness": 1.0,
+        },
+        "injury_chance": 0.0,
+    },
+}

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -284,17 +284,15 @@ class SeasonManager:
                         if hasattr(player, "injuries"):
                             player.injuries.clear()
 
-                # Weekly practice training gains
-                apply_weekly_training(
-                    player,
-                    {
-                        "team": team,
-                        "roster": getattr(team, "roster", []),
-                        "practice_squad": getattr(team, "practice_squad", None),
-                        "coach_quality": getattr(team, "coach_quality", getattr(team, "training_quality", 1.0)),
-                        "week_number": just_ended_week,
-                    },
-                )
+                # No longer run per-player focus training here
+
+            # Team training plan using weighted drills
+            from ..player.weekly_training import assign_training, apply_training_plan
+
+            assign_training(team, just_ended_week)
+            plan = getattr(getattr(team, "training_plan", {}), "get", lambda w: None)(just_ended_week)
+            if plan:
+                apply_training_plan(team, plan, just_ended_week)
 
             # Call fatigue accumulation hook (empty list for heavy_usage_players for now)
             accumulate_season_fatigue_for_team(team, [])

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/weekly_training.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/weekly_training.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import random
 from typing import Any, Dict, Iterable
 
+from gridiron_gm.gridiron_gm_pkg.config.training_catalog import TRAINING_CATALOG
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.injury_manager import (
+    InjuryEngine,
+)
+
+_injury_engine = InjuryEngine()
+
 # Attributes considered physical for slower capped growth
 PHYSICAL_ATTRIBUTES = {
     "speed",
@@ -33,6 +40,117 @@ FOCUS_MAP = {
     "strength": ["strength"],
     "speed": ["speed"],
 }
+
+# Base increase applied before weighting and multipliers
+BASE_GROWTH = 0.2
+
+
+def apply_training_plan(team: Any, plan: Dict[str, Any], week: int) -> None:
+    """Apply a weighted training drill to appropriate players."""
+
+    if not plan:
+        return
+
+    drill_name = plan.get("drill")
+    drill = TRAINING_CATALOG.get(drill_name)
+    if not drill:
+        return
+
+    # Determine coach multiplier
+    quality = getattr(team, "coach_quality", getattr(team, "training_quality", 1.0))
+    try:
+        mult = float(quality)
+    except (TypeError, ValueError):
+        mult = 1.0
+    mult = min(1.2, max(0.8, mult))
+
+    target_type = plan.get("type", "team")
+    players: Iterable[Any]
+    if target_type == "player":
+        player = plan.get("player")
+        players = [player] if player is not None else []
+    elif target_type == "position":
+        pos = str(plan.get("position", "")).upper()
+        players = [p for p in getattr(team, "roster", []) if getattr(p, "position", "").upper() == pos]
+    else:
+        players = [p for p in getattr(team, "roster", [])]
+
+    plan_intensity = float(plan.get("intensity", 1.0))
+
+    for player in players:
+        if player is None or getattr(player, "is_injured", False):
+            continue
+
+        # Ensure tracking containers exist
+        if not hasattr(player, "training_log"):
+            player.training_log = {}
+        if not hasattr(player, "_season_physical_growth"):
+            player._season_physical_growth = {}
+
+        for attr, weight in drill.get("attribute_weights", {}).items():
+            container, _ = _get_attr_container(player, attr)
+            if container is None:
+                continue
+
+            gain = BASE_GROWTH * weight * mult
+            if target_type == "team":
+                gain *= 0.5
+            elif target_type == "player":
+                gain *= 1.2
+
+            if attr in PHYSICAL_ATTRIBUTES:
+                total = player._season_physical_growth.get(attr, 0.0)
+                if total >= 2.0:
+                    continue
+                gain = min(gain, 2.0 - total)
+                player._season_physical_growth[attr] = total + gain
+
+            container[attr] = round(container.get(attr, 0) + gain, 2)
+            player.training_log.setdefault(week, {})[attr] = round(gain, 3)
+
+        # Injury risk from training
+        injury_chance = drill.get("injury_chance", 0.0) * plan_intensity
+        if injury_chance > 0 and random.random() < injury_chance:
+            _injury_engine.assign_injury(player)
+
+
+def assign_training(team: Any, week: int) -> None:
+    """Assign a simple CPU training plan if none provided."""
+
+    if getattr(team, "user_controlled", False):
+        return
+
+    if not hasattr(team, "training_plan"):
+        team.training_plan = {}
+
+    if week in team.training_plan:
+        return
+
+    # Determine weakest position by average overall
+    pos_scores: Dict[str, float] = {}
+    for p in getattr(team, "roster", []):
+        if getattr(p, "is_injured", False):
+            continue
+        pos_scores.setdefault(p.position, []).append(getattr(p, "overall", 0))
+    if not pos_scores:
+        return
+    avg_scores = {pos: sum(vals) / len(vals) for pos, vals in pos_scores.items()}
+    weakest = min(avg_scores, key=avg_scores.get)
+
+    drill_name = None
+    for name, drill in TRAINING_CATALOG.items():
+        if drill["positions"] == "ALL" or weakest in drill["positions"]:
+            drill_name = name
+            break
+    if drill_name is None:
+        drill_name = next(iter(TRAINING_CATALOG))
+
+    team.training_plan[week] = {
+        "type": "position",
+        "position": weakest,
+        "drill": drill_name,
+        "intensity": 1.0,
+    }
 
 
 def _get_attr_container(player: Any, attr: str) -> tuple[Dict[str, float], str] | tuple[None, None]:

--- a/gridiron_gm/gridiron_gm_pkg/tests/test_weekly_training.py
+++ b/gridiron_gm/gridiron_gm_pkg/tests/test_weekly_training.py
@@ -1,76 +1,92 @@
 import sys
 from pathlib import Path
+import random
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+random.seed(0)
 
-from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.weekly_training import apply_weekly_training
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.weekly_training import (
+    apply_training_plan,
+)
+from gridiron_gm.gridiron_gm_pkg.config.training_catalog import TRAINING_CATALOG
+
 
 class DummyAttrs:
     def __init__(self):
-        self.core = {"throw_accuracy_short": 60, "throw_power": 60, "awareness": 50, "speed": 80}
+        self.core = {
+            "throw_accuracy_short": 60,
+            "throw_power": 60,
+            "strength": 50,
+            "agility": 70,
+            "awareness": 50,
+        }
         self.position_specific = {"route_running_short": 65}
 
+
 class DummyPlayer:
-    def __init__(self):
+    def __init__(self, position="QB"):
+        self.position = position
         self.attributes = DummyAttrs()
-        self.training_focus = "throwing"
         self.is_injured = False
+        self.training_log = {}
+        self._season_physical_growth = {}
+
 
 class DummyTeam:
-    def __init__(self, player, quality=1.0):
-        self.roster = [player]
-        self.practice_squad = []
+    def __init__(self, players, quality=1.0):
+        self.roster = players
         self.coach_quality = quality
-        self.current_week = 1
+        self.training_plan = {}
 
 
-def test_training_applies_growth(monkeypatch):
-    player = DummyPlayer()
-    team = DummyTeam(player, quality=1.1)
+def test_weighted_growth_player_drill():
+    player = DummyPlayer("QB")
+    team = DummyTeam([player])
+    plan = {"type": "player", "player": player, "drill": "QB Accuracy"}
 
-    monkeypatch.setattr("random.uniform", lambda a, b: b)
+    apply_training_plan(team, plan, 1)
 
-    apply_weekly_training(player, team)
-
-    # Accuracy (mental) should grow more than throw_power (physical)
-    assert player.attributes.core["throw_accuracy_short"] > 60
-    assert player.attributes.core["throw_power"] > 60
-    assert player.attributes.core["throw_accuracy_short"] - 60 > player.attributes.core["throw_power"] - 60
+    assert round(player.attributes.core["throw_accuracy_short"], 2) == 60 + round(0.2 * 1.0 * 1.2, 2)
+    assert round(player.attributes.core["throw_power"], 2) == 60 + round(0.2 * 0.5 * 1.2, 2)
+    assert 1 in player.training_log
 
 
-def test_injured_or_no_focus_no_growth(monkeypatch):
-    player = DummyPlayer()
-    team = DummyTeam(player)
-    player.training_focus = None
+def test_team_vs_position_drill():
+    qb = DummyPlayer("QB")
+    wr = DummyPlayer("WR")
+    team = DummyTeam([qb, wr])
+    team_plan = {"type": "team", "drill": "Strength Circuit"}
+    apply_training_plan(team, team_plan, 1)
+    assert round(qb.attributes.core["strength"], 2) == 50 + round(0.2 * 1.0 * 1.0 * 0.5, 2)
+    wr_strength_after = wr.attributes.core["strength"]
 
-    monkeypatch.setattr("random.uniform", lambda a, b: b)
-    apply_weekly_training(player, team)
-    assert player.attributes.core["throw_accuracy_short"] == 60
-
-    player.training_focus = "throwing"
-    player.is_injured = True
-    apply_weekly_training(player, team)
-    assert player.attributes.core["throw_accuracy_short"] == 60
-
-
-def test_physical_growth_cap(monkeypatch):
-    player = DummyPlayer()
-    player.training_focus = "speed"
-    team = DummyTeam(player)
-
-    monkeypatch.setattr("random.uniform", lambda a, b: b)
-    for _ in range(20):
-        apply_weekly_training(player, team)
-    # cap at +2 total
-    assert round(player.attributes.core["speed"] - 80, 3) <= 2.0
+    pos_plan = {"type": "position", "position": "WR", "drill": "WR Footwork"}
+    apply_training_plan(team, pos_plan, 2)
+    assert round(wr.attributes.position_specific["route_running_short"], 2) == 65 + round(0.2 * 1.0 * 1.0, 2)
+    assert wr.attributes.core["strength"] == wr_strength_after
 
 
-def test_coach_multiplier(monkeypatch):
-    player = DummyPlayer()
-    team = DummyTeam(player, quality=1.2)
+def test_ineligible_players_skipped():
+    qb = DummyPlayer("QB")
+    injured_qb = DummyPlayer("QB")
+    injured_qb.is_injured = True
+    team = DummyTeam([qb, injured_qb])
+    plan = {"type": "position", "position": "QB", "drill": "QB Accuracy"}
+    apply_training_plan(team, plan, 1)
+    assert "throw_accuracy_short" in qb.training_log[1]
+    assert 1 not in injured_qb.training_log
 
-    monkeypatch.setattr("random.uniform", lambda a, b: b)
-    apply_weekly_training(player, team)
 
-    # mental attribute gain should reflect multiplier 1.2
-    assert round(player.attributes.core["throw_accuracy_short"] - 60, 2) == round(0.5 * 1.2, 2)
+def test_training_injury_triggered():
+    player = DummyPlayer("QB")
+    team = DummyTeam([player])
+    plan = {
+        "type": "player",
+        "player": player,
+        "drill": "Strength Circuit",
+        "intensity": 1000,
+    }
+
+    apply_training_plan(team, plan, 1)
+
+    assert player.is_injured


### PR DESCRIPTION
## Summary
- expand training catalog with `injury_chance` values
- allow training drills to injure players based on drill intensity
- CPU teams include a default intensity in assigned plans
- update tests for deterministic randomness and new injury behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843370dcf4883279a80015c2c5e57b7