### PR TITLE
Implement daily training system

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/config/injury_catalog.py
+++ b/gridiron_gm/gridiron_gm_pkg/config/injury_catalog.py
@@ -89,7 +89,10 @@ INJURY_CATALOG = {
         "long_term": [
             {"type": "recurrence", "target": "back", "change": 10, "duration": "season", "notes": "Recurring minor back pain"}
         ],
-        "short_term": [{"type": "attribute", "target": "strength", "change": -2}],
+        "short_term": [
+            {"type": "attribute", "target": "strength", "change": -2},
+            {"type": "attribute", "target": "throw_power", "change": -2}
+        ],
         "career_ending": False,
         "injury_context": "on_field"
     },
@@ -188,7 +191,10 @@ INJURY_CATALOG = {
         "long_term": [
             {"type": "recurrence", "target": "shoulder", "change": 20, "duration": "career", "notes": "Shoulder instability"}
         ],
-        "short_term": [{"type": "attribute", "target": "strength", "change": -2}],
+        "short_term": [
+            {"type": "attribute", "target": "strength", "change": -2},
+            {"type": "attribute", "target": "throw_power", "change": -2}
+        ],
         "career_ending": False,
         "injury_context": "on_field"
     },

--- a/gridiron_gm/gridiron_gm_pkg/config/training_catalog.py
+++ b/gridiron_gm/gridiron_gm_pkg/config/training_catalog.py
@@ -9,6 +9,14 @@ TRAINING_CATALOG = {
         },
         "injury_chance": 0.002,
     },
+    "QB Accuracy": {
+        "positions": ["QB"],
+        "attribute_weights": {
+            "throw_accuracy_short": 1.0,
+            "throw_power": 0.5,
+        },
+        "injury_chance": 0.002,
+    },
     "QB Scramble Drill": {
         "positions": ["QB"],
         "attribute_weights": {
@@ -547,6 +555,11 @@ TRAINING_CATALOG = {
             "agility": 1.0,
             "balance": 0.5,
         },
+        "injury_chance": 0.005,
+    },
+    "Strength Circuit": {
+        "positions": "ALL",
+        "attribute_weights": {"strength": 1.0},
         "injury_chance": 0.005,
     },
     "Walkthrough Practice": {

--- a/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
@@ -79,7 +79,7 @@ class Player:
         self.on_injured_reserve = False
         self.is_injured = False
         # Track active temporary penalties from injuries
-        self.active_injury_effects = []
+        self.active_injury_effects = {}
 
         self.traits = {
             "training": [],
@@ -109,6 +109,8 @@ class Player:
         self.scouted_potential = {}
         self.last_attribute_values = {}
         self.no_growth_years = {}
+        # Track periodic snapshots of attributes
+        self.progress_history = {}
 
     def init_position_attributes(self):
         position = self.position.upper()
@@ -336,10 +338,14 @@ class Player:
         if base is None:
             return None
 
+        effects = getattr(self, "active_injury_effects", {})
         penalty = 0
-        for eff in getattr(self, "active_injury_effects", []):
-            if eff.get("attribute") == attr:
-                penalty += eff.get("change", 0)
+        if isinstance(effects, dict):
+            penalty = effects.get(attr, 0)
+        else:
+            for eff in effects:
+                if isinstance(eff, dict) and eff.get("attribute") == attr:
+                    penalty += eff.get("change", 0)
 
         return base + penalty
 
@@ -400,7 +406,8 @@ class Player:
             "hidden_caps": self.hidden_caps,
             "scouted_potential": self.scouted_potential,
             "last_attribute_values": self.last_attribute_values,
-            "no_growth_years": self.no_growth_years
+            "no_growth_years": self.no_growth_years,
+            "progress_history": self.progress_history
         }
 
     @staticmethod
@@ -458,6 +465,7 @@ class Player:
         player.scouted_potential = data.get("scouted_potential", {})
         player.last_attribute_values = data.get("last_attribute_values", {})
         player.no_growth_years = data.get("no_growth_years", {})
+        player.progress_history = data.get("progress_history", {})
         return player
 
 def ensure_player_objects(team):
@@ -469,3 +477,4 @@ def ensure_player_objects(team):
         else:
             new_roster.append(p)
     team.roster = new_roster
+

--- a/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/daily_training.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/systems/player/daily_training.py
@@ -1,0 +1,143 @@
+"""Daily team training system."""
+
+from __future__ import annotations
+
+import random
+from datetime import date as date_type
+from typing import Dict, Any, Iterable
+
+from gridiron_gm.gridiron_gm_pkg.config.training_catalog import TRAINING_CATALOG
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.injury_manager import InjuryEngine
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.weekly_training import _get_attr_container
+
+_DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+_injury_engine = InjuryEngine()
+
+
+def _extract_week_day(date: Any) -> tuple[str, str]:
+    """Return week number string and capitalized day name from various date types."""
+    if hasattr(date, "current_week") and hasattr(date, "current_day_index"):
+        return str(date.current_week), _DAYS[date.current_day_index]
+    if isinstance(date, tuple) and len(date) == 2:
+        week, day = date
+        day_name = day if isinstance(day, str) else _DAYS[int(day)]
+        return str(week), day_name.capitalize()
+    if isinstance(date, date_type):
+        week = date.isocalendar().week
+        return str(week), date.strftime("%A")
+    # Fallback: treat as mapping
+    week = str(getattr(date, "week", 0))
+    day = getattr(date, "day", "Monday")
+    return week, str(day).capitalize()
+
+
+def should_train_today(team: Any, date: Any, schedule_by_team: Dict[str, Iterable[Dict[str, Any]]]) -> bool:
+    """Return True if the team can hold training on the given date."""
+    week, day_name = _extract_week_day(date)
+
+    games = schedule_by_team.get(getattr(team, "id", None), [])
+    for game in games:
+        if str(game.get("week")) == week and str(game.get("day", "")).capitalize() == day_name:
+            return False
+
+    # Check travel day (day before an away game)
+    idx = _DAYS.index(day_name)
+    next_day = _DAYS[(idx + 1) % 7]
+    next_week = str(int(week) + 1) if idx == 6 else week
+    for game in games:
+        if (
+            str(game.get("day", "")).capitalize() == next_day
+            and not game.get("home", True)
+            and str(game.get("week")) in {week, next_week}
+        ):
+            return False
+    return True
+
+
+class CoachTrainingAI:
+    """Simple auto-assignment helper for training drills."""
+
+    def choose_drill(self, player: Any) -> str | None:
+        position = str(getattr(player, "position", "")).upper()
+        matches = [
+            name
+            for name, drill in TRAINING_CATALOG.items()
+            if drill.get("positions") == "ALL" or position in drill.get("positions", [])
+        ]
+        return random.choice(matches) if matches else None
+
+
+def assign_training(team: Any, date: Any) -> Dict[str, str]:
+    """Return mapping of player_id to drill name for today's training."""
+    assignments: Dict[str, str] = {}
+    date_key = str(date)
+    manual = getattr(team, "training_schedule", {}).get(date_key, {})
+    assignments.update(manual)
+
+    available_players = [p for p in getattr(team, "roster", []) if not getattr(p, "is_injured", False)]
+    available_players = [p for p in available_players if p.id not in assignments]
+    random.shuffle(available_players)
+    ai = CoachTrainingAI()
+    slots = max(0, 3 - len(assignments))
+    for player in available_players[:slots]:
+        drill = ai.choose_drill(player)
+        if drill:
+            assignments[player.id] = drill
+    return assignments
+
+
+def apply_training(team: Any, date: Any, drill_assignments: Dict[str, str]) -> None:
+    """Apply drill effects to the assigned players."""
+    if not drill_assignments:
+        return
+
+    for player in getattr(team, "roster", []):
+        drill_name = drill_assignments.get(player.id)
+        if not drill_name:
+            continue
+        drill = TRAINING_CATALOG.get(drill_name, {})
+        for attr, weight in drill.get("attribute_weights", {}).items():
+            container, _ = _get_attr_container(player, attr)
+            if container is None and hasattr(player, attr):
+                container = player.__dict__
+            if container is None:
+                continue
+            container[attr] = container.get(attr, 0) + weight
+        chance = drill.get("injury_chance", 0.0)
+        if chance and random.random() < chance:
+            _injury_engine.assign_injury(player)
+
+
+def run_daily_training(date: Any, league_teams: Iterable[Any], schedule_by_team: Dict[str, Any]) -> None:
+    """Run training for all teams for the given date."""
+    for team in league_teams:
+        if should_train_today(team, date, schedule_by_team):
+            assignments = assign_training(team, date)
+            apply_training(team, date, assignments)
+
+
+def log_season_progress_checkpoint(date: Any, all_players: Iterable[Any], checkpoint_label: str) -> None:
+    """Record attribute snapshot for each player with provided label."""
+    year = getattr(date, "year", None)
+    if year is None and isinstance(date, (tuple, list)):
+        year = date[0]
+    label = f"{year}-{checkpoint_label}"
+    for player in all_players:
+        hist = getattr(player, "progress_history", {})
+        snapshot: Dict[str, Any] = {}
+        attrs = getattr(player, "attributes", None)
+        if attrs is not None:
+            snapshot.update(getattr(attrs, "core", {}))
+            snapshot.update(getattr(attrs, "position_specific", {}))
+        for field, val in player.__dict__.items():
+            if field.startswith("_"):
+                continue
+            if isinstance(val, (int, float)) and field not in snapshot:
+                snapshot[field] = val
+        hist[label] = snapshot
+        # Keep only most recent two snapshots
+        if len(hist) > 2:
+            for key in sorted(hist.keys())[:-2]:
+                hist.pop(key, None)
+        player.progress_history = hist
+

--- a/gridiron_gm/gridiron_gm_pkg/tests/test_daily_training_system.py
+++ b/gridiron_gm/gridiron_gm_pkg/tests/test_daily_training_system.py
@@ -1,0 +1,84 @@
+import sys
+from pathlib import Path
+from datetime import date
+import random
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+random.seed(0)
+
+from gridiron_gm.gridiron_gm_pkg.simulation.systems.player.daily_training import (
+    should_train_today,
+    assign_training,
+    apply_training,
+    run_daily_training,
+    log_season_progress_checkpoint,
+)
+from gridiron_gm.gridiron_gm_pkg.config.training_catalog import TRAINING_CATALOG
+
+
+class DummyAttrs:
+    def __init__(self):
+        self.core = {
+            "throw_accuracy_short": 60,
+            "throw_power": 60,
+            "strength": 50,
+        }
+        self.position_specific = {}
+
+
+class DummyPlayer:
+    def __init__(self, position="QB"):
+        self.id = position
+        self.position = position
+        self.attributes = DummyAttrs()
+        self.is_injured = False
+        self.progress_history = {}
+
+
+class DummyTeam:
+    def __init__(self, players):
+        self.id = "T1"
+        self.roster = players
+        self.training_schedule = {}
+
+
+def test_training_eligibility():
+    schedule = {
+        "T1": [
+            {"week": "1", "day": "Monday", "home": False},
+        ]
+    }
+    team = DummyTeam([DummyPlayer()])
+    # Game day
+    assert not should_train_today(team, (1, "Monday"), schedule)
+    # Travel day before away game
+    assert not should_train_today(team, (1, "Sunday"), schedule)
+    # Normal day
+    assert should_train_today(team, (1, "Wednesday"), schedule)
+
+
+def test_assign_and_apply_training(monkeypatch):
+    player = DummyPlayer()
+    team = DummyTeam([player])
+    schedule = {"T1": []}
+    monkeypatch.setattr(
+        "gridiron_gm.gridiron_gm_pkg.simulation.systems.player.daily_training.random.choice",
+        lambda seq: seq[0],
+    )
+    assignments = assign_training(team, (1, "Wednesday"))
+    assert player.id in assignments
+    apply_training(team, (1, "Wednesday"), assignments)
+    drill = TRAINING_CATALOG[assignments[player.id]]
+    expected = 60 + list(drill["attribute_weights"].values())[0]
+    assert player.attributes.core["throw_accuracy_short"] == expected
+
+
+def test_progress_checkpoint():
+    player = DummyPlayer()
+    log_season_progress_checkpoint(date(2025, 8, 1), [player], "preseason")
+    assert "2025-preseason" in player.progress_history
+    # Only keep two snapshots
+    log_season_progress_checkpoint(date(2025, 12, 1), [player], "postseason")
+    log_season_progress_checkpoint(date(2026, 8, 1), [player], "preseason")
+    assert len(player.progress_history) == 2
+


### PR DESCRIPTION
## Summary
- add daily training module with auto-assignment and snapshot logging
- support progress history field on Player serialization
- adjust injury manager to use dictionaries for active effects
- tweak injury catalog and add missing drills
- test the daily training flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843beded8b08327bc7ed194757a1cbd