### PR TITLE
Add DNA-based weekly player progression

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/players/player_dna.py
+++ b/gridiron_gm/gridiron_gm_pkg/players/player_dna.py
@@ -37,22 +37,7 @@ DNA_MUTATIONS: Dict[str, Dict] = {
 }
 
 from typing import Iterable, Optional, Dict
-# === Growth Curve Generation ===
-def generate_growth_curve(
-    min_age: int = 20,
-    max_age: int = 40,
-    peak_age: Optional[int] = None,
-    peak_duration: Optional[int] = None,
-) -> Dict[int, float]:
-    """Return a per-age growth multiplier curve."""
-    if max_age <= min_age:
-        raise ValueError("max_age must be greater than min_age")
 
-    peak_age = peak_age or int(max(min(random.gauss(27, 2), 32), 22))
-    plateau_years = peak_duration or random.randint(1, 4)
-
-    growth_speed = random.choice([0.8, 1.0, 1.2])
-    
 # === PLAYER TRAITS ===
 PLAYER_TRAITS = [
     "Leader",
@@ -155,7 +140,12 @@ class PlayerDNA:
         return obj
 
 
-def generate_growth_curve(min_age: int = 20, max_age: int = 34) -> Dict[int, float]:
+def generate_growth_curve(
+    min_age: int = 20,
+    max_age: int = 34,
+    peak_age: Optional[int] = None,
+    peak_duration: Optional[int] = None,
+) -> Dict[int, float]:
     """Return a growth multiplier curve keyed by age.
 
     The curve has an ascension phase leading into a short prime plateau followed
@@ -168,8 +158,8 @@ def generate_growth_curve(min_age: int = 20, max_age: int = 34) -> Dict[int, flo
         raise ValueError("max_age must be greater than min_age")
 
     # --- Key parameters
-    peak_age = int(max(min(random.gauss(27, 2), 32), 22))
-    plateau_years = random.randint(1, 4)
+    peak_age = peak_age or int(max(min(random.gauss(27, 2), 32), 22))
+    plateau_years = peak_duration or random.randint(1, 4)
 
     growth_speed = random.choice([0.8, 1.0, 1.2])  # slow/med/fast
     decline_speed = random.choice([0.8, 1.0, 1.2, 1.4])

--- a/tests/test_player_dna.py
+++ b/tests/test_player_dna.py
@@ -57,3 +57,21 @@ def test_generate_player_growth_tables(tmp_path):
     for p in players:
         assert (tmp_path / f"{p.id}_growth.csv").exists()
 
+
+def test_growth_curve_has_peak_and_decline():
+    dna = PlayerDNA.generate_random_dna("QB")
+    curve = dna.growth_curve
+    ages = sorted(curve)
+    peak = dna.peak_age
+
+    # Ascending portion up to the peak
+    ascending = all(
+        curve[a] <= curve[min(peak, a + 1)] + 0.05 for a in ages if a < peak
+    )
+    # Descending portion after the peak
+    descending = all(
+        curve[a] >= curve[min(ages[-1], a + 1)] - 0.05 for a in ages if a >= peak
+    )
+
+    assert ascending and descending
+


### PR DESCRIPTION
## Summary
- overhaul player progression to use each player's DNA-driven growth curve and regression
- expose tunable constants in `player_progression`
- fix duplicate growth curve function and support optional peak parameters
- ensure growth curve has a peak and decline with new test

## Testing
- `pip install pandas matplotlib -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684646d2e3ec8327a9d030d69ac399fd