### PR TITLE
Add PlayerDNA growth system

### DIFF
--- a/gridiron_gm/gridiron_gm_pkg/players/player_dna.py
+++ b/gridiron_gm/gridiron_gm_pkg/players/player_dna.py
@@ -1,19 +1,34 @@
-"""Procedural DNA system for players."""
+"""Player DNA system handling growth, traits and attribute caps."""
+
 from __future__ import annotations
 
 import random
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 
-# === DNA MUTATIONS ===
-DNA_MUTATIONS: Dict[str, Dict] = {
+# === TRAITS (Behavioral Modifiers) ===
+TRAIT_POOL = [
+    "Leader",
+    "Mentor",
+    "Hard Worker",
+    "Low Motor",
+    "Resilient",
+    "Ego Driven",
+    "Team Player",
+    "Hot-Headed",
+    "System Dependent",
+    "Spotlight Seeker",
+]
+
+# === MUTATIONS (Rare DNA Modifiers) ===
+DNA_MUTATIONS = {
     "Generational Talent": {
         "attribute_cap_boosts": {"physical": 0.1, "mental": 0.1, "technical": 0.1},
         "dev_speed_multiplier": 1.25,
     },
     "Physical Freak": {
-        "attribute_cap_boosts": {"physical": 0.2},
-        "dev_speed_multiplier": 1.00,
+        "attribute_cap_boosts": {"physical": 0.20},
+        "dev_speed_multiplier": 0.85,
     },
     "Football Savant": {
         "attribute_cap_boosts": {"mental": 0.15},
@@ -36,41 +51,59 @@ DNA_MUTATIONS: Dict[str, Dict] = {
     },
 }
 
-from typing import Iterable, Optional, Dict
 
-# === PLAYER TRAITS ===
-PLAYER_TRAITS = [
-    "Leader",
-    "Spotlight Seeker",
-    "Mentor",
-    "Hot-Headed",
-    "Low Motor",
-    "Hard Worker",
-    "Team Player",
-    "Selfish",
-    "Resilient",
-    "Ego Driven",
-]
+# === ATTRIBUTE CAPS STRUCTURE ===
+def generate_attribute_caps(dev_focus: Dict[str, float]) -> Dict[str, Dict]:
+    caps: Dict[str, Dict] = {}
+    for attr in [
+        "speed",
+        "strength",
+        "awareness",
+        "agility",
+        "tackle",
+        "catching",
+        "route_running_short",
+    ]:
+        base = random.randint(70, 90)
+        soft_cap = int(base + random.randint(2, 5))
+        hard_cap = int(soft_cap + random.randint(2, 5))
+        caps[attr] = {
+            "current": base,
+            "soft_cap": min(soft_cap, 98),
+            "hard_cap": min(hard_cap, 99),
+            "breakout_history": [],
+        }
+    return caps
 
 
+@dataclass
 class PlayerDNA:
-    """Procedural growth and trait profile for a player."""
+    """Container for a player's long-term development profile."""
 
-    def __init__(self) -> None:
-        self.growth_type = self._choose_growth_type()
-        self.regression_type = self._choose_regression_type()
-        self.dev_speed = random.uniform(0.75, 1.25)
+    growth_arc: str = field(init=False)
+    regression_profile: str = field(init=False)
+    dev_speed: float = field(init=False)
+    dev_focus: Dict[str, float] = field(init=False)
+    traits: List[str] = field(init=False)
+    mutation: Optional[str] = field(init=False)
+    attribute_caps: Dict[str, Dict] = field(init=False)
+    scouted_caps: Dict[str, int] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.growth_arc = random.choice(["early", "late", "balanced", "rollercoaster"])
+        self.regression_profile = random.choice(
+            ["early_decline", "late_decline", "injury_decline", "gradual"]
+        )
+        self.dev_speed = round(random.uniform(0.75, 1.25), 2)
         self.dev_focus = self._generate_dev_focus_weights()
-        self.attribute_caps = self._generate_attribute_caps()
-        self.mutation = self._assign_mutation()
         self.traits = self._assign_traits()
+        self.mutation = self._assign_mutation()
+        self.attribute_caps = generate_attribute_caps(self.dev_focus)
+        if self.mutation:
+            self.apply_mutation_effects()
+        self.scouted_caps = self._generate_scouted_caps()
 
-    def _choose_growth_type(self) -> str:
-        return random.choice(["early_peak", "late_bloomer", "rollercoaster", "flatline"])
-
-    def _choose_regression_type(self) -> str:
-        return random.choice(["early_decline", "late_decline", "injury_decline", "gradual_decline"])
-
+    # --- Helper generators -------------------------------------------------
     def _generate_dev_focus_weights(self) -> Dict[str, float]:
         weights = [random.uniform(0.25, 0.45) for _ in range(3)]
         total = sum(weights)
@@ -80,210 +113,125 @@ class PlayerDNA:
             "technical": weights[2] / total,
         }
 
-    def _generate_attribute_caps(self) -> Dict[str, int]:
-        return {
-            "speed": random.randint(80, 99),
-            "strength": random.randint(75, 95),
-            "awareness": random.randint(70, 95),
-            "agility": random.randint(75, 95),
-            "throw_accuracy_short": random.randint(60, 95),
-            "tackle_dl": random.randint(60, 95),
-            "route_running_short": random.randint(60, 95),
-        }
+    def _assign_traits(self) -> List[str]:
+        count = random.choices([0, 1, 2, 3], weights=[0.1, 0.4, 0.35, 0.15])[0]
+        return random.sample(TRAIT_POOL, count)
 
     def _assign_mutation(self) -> Optional[str]:
-        roll = random.random()
-        if roll <= 0.05:
-            return random.choice(list(DNA_MUTATIONS.keys()))
-        return None
+        return (
+            random.choice(list(DNA_MUTATIONS.keys()))
+            if random.random() < 0.05
+            else None
+        )
 
-    def _assign_traits(self) -> Iterable[str]:
-        trait_count = random.choices([0, 1, 2, 3], weights=[0.1, 0.4, 0.35, 0.15])[0]
-        return random.sample(PLAYER_TRAITS, trait_count)
+    def _generate_scouted_caps(self) -> Dict[str, int]:
+        offset = lambda cap: cap + random.randint(-5, 10)
+        return {
+            attr: offset(caps["hard_cap"]) for attr, caps in self.attribute_caps.items()
+        }
 
-    def apply_mutation_effects(self, attr_caps: Dict[str, int]) -> Dict[str, int]:
-        """Apply mutation bonuses to attribute caps."""
+    # --- Mutation effects ---------------------------------------------------
+    def apply_mutation_effects(self) -> None:
         if not self.mutation:
-            return attr_caps
+            return
+        details = DNA_MUTATIONS[self.mutation]
+        boosts = details.get("attribute_cap_boosts", {})
+        for group, boost in boosts.items():
+            for attr, caps in self.attribute_caps.items():
+                if group in attr:
+                    caps["soft_cap"] = min(98, int(caps["soft_cap"] * (1 + boost)))
+                    caps["hard_cap"] = min(99, int(caps["hard_cap"] * (1 + boost)))
 
-        mutation = DNA_MUTATIONS[self.mutation]
-        new_caps = attr_caps.copy()
+        mult = details.get("dev_speed_multiplier")
+        if mult:
+            self.dev_speed = round(self.dev_speed * mult, 2)
 
-        if "attribute_cap_boosts" in mutation:
-            for group, boost in mutation["attribute_cap_boosts"].items():
-                for attr in attr_caps:
-                    if group in attr:
-                        new_caps[attr] = min(99, int(attr_caps[attr] * (1 + boost)))
-        return new_caps
+    # --- Weekly progression -------------------------------------------------
+    def apply_weekly_growth(
+        self, usage_factor: float = 1.0, coaching_quality: float = 1.0
+    ) -> None:
+        for attr, caps in self.attribute_caps.items():
+            cur = caps["current"]
+            soft_cap = caps["soft_cap"]
+            hard_cap = caps["hard_cap"]
+            if cur >= hard_cap:
+                continue
+            base_gain = 0.1 * self.dev_speed * usage_factor * coaching_quality
+            if cur < soft_cap:
+                growth = base_gain
+            else:
+                growth = base_gain * 0.25
+            caps["current"] = min(hard_cap, cur + growth)
 
+    def check_breakout(
+        self,
+        attr: str,
+        production_metric: bool,
+        snap_share: float,
+        week: int,
+        traits: Optional[List[str]] = None,
+    ) -> None:
+        traits = traits or []
+        caps = self.attribute_caps[attr]
+        if (
+            caps["current"] >= caps["soft_cap"] - 1
+            and production_metric
+            and snap_share > 0.7
+        ):
+            if "Hard Worker" in self.traits or "Resilient" in traits:
+                caps["current"] = min(
+                    caps["hard_cap"], caps["current"] + random.randint(2, 4)
+                )
+                caps["soft_cap"] = min(
+                    caps["hard_cap"], caps["soft_cap"] + random.randint(1, 3)
+                )
+                caps["breakout_history"].append(week)
+
+    # --- Regression ---------------------------------------------------------
+    def regress_player(self, age: int, is_injured: bool = False) -> None:
+        age_trigger = {"early": 27, "balanced": 30, "late": 32, "rollercoaster": 29}
+        drop = 0.5 if self.regression_profile == "gradual" else 1.0
+        trigger = age_trigger.get(self.growth_arc, 29)
+        if age >= trigger:
+            for attr, caps in self.attribute_caps.items():
+                if is_injured and DNA_MUTATIONS.get(self.mutation, {}).get(
+                    "injury_regression_reduction"
+                ):
+                    continue
+                drop_mod = 1.5 if attr in ["speed", "agility"] else 1.0
+                caps["current"] = max(0, caps["current"] - drop * drop_mod)
+
+    # --- Serialization ------------------------------------------------------
     def to_dict(self) -> Dict:
         return {
-            "growth_type": self.growth_type,
-            "regression_type": self.regression_type,
+            "growth_arc": self.growth_arc,
+            "regression_profile": self.regression_profile,
             "dev_speed": self.dev_speed,
             "dev_focus": self.dev_focus,
-            "attribute_caps": self.attribute_caps,
+            "traits": self.traits,
             "mutation": self.mutation,
-            "traits": list(self.traits),
+            "attribute_caps": self.attribute_caps,
+            "scouted_caps": self.scouted_caps,
         }
 
     @classmethod
     def from_dict(cls, data: Dict) -> "PlayerDNA":
         obj = cls.__new__(cls)
-        obj.growth_type = data.get("growth_type")
-        obj.regression_type = data.get("regression_type")
-        obj.dev_speed = data.get("dev_speed", 1.0)
-        obj.dev_focus = data.get("dev_focus", {})
-        obj.attribute_caps = data.get("attribute_caps", {})
-        obj.mutation = data.get("mutation")
-        obj.traits = data.get("traits", [])
+        for field_name in [
+            "growth_arc",
+            "regression_profile",
+            "dev_speed",
+            "dev_focus",
+            "traits",
+            "mutation",
+            "attribute_caps",
+            "scouted_caps",
+        ]:
+            setattr(obj, field_name, data.get(field_name))
         return obj
 
-
-def generate_growth_curve(
-    min_age: int = 20,
-    max_age: int = 34,
-    peak_age: Optional[int] = None,
-    peak_duration: Optional[int] = None,
-) -> Dict[int, float]:
-    """Return a growth multiplier curve keyed by age.
-
-    The curve has an ascension phase leading into a short prime plateau followed
-    by decline. Each player receives a unique curve based on randomised peak
-    age, plateau length and slope parameters. Values are clamped between 0.6 and
-    1.05 and include a small amount of per-age noise.
-    """
-
-    if max_age <= min_age:
-        raise ValueError("max_age must be greater than min_age")
-
-    # --- Key parameters
-    peak_age = peak_age or int(max(min(random.gauss(27, 2), 32), 22))
-    plateau_years = peak_duration or random.randint(1, 4)
-
-    growth_speed = random.choice([0.8, 1.0, 1.2])  # slow/med/fast
-    decline_speed = random.choice([0.8, 1.0, 1.2, 1.4])
-
-    start_value = random.uniform(0.72, 0.82)
-    years_to_peak = max(1, peak_age - min_age)
-    base_slope = (1.0 - start_value) / years_to_peak
-    growth_slope = base_slope * growth_speed
-    decline_slope = base_slope * decline_speed
-
-    curve: Dict[int, float] = {}
-    value = start_value
-    for age in range(min_age, max_age + 1):
-        if age < peak_age:
-            value += growth_slope
-        elif age < peak_age + plateau_years:
-            value = value
-        else:
-            value -= decline_slope
-        noise = random.uniform(-0.02, 0.02)
-        final = max(0.6, min(1.1, value + noise))
-        curve[age] = round(final, 3)
-    return curve
-
-
-POSITION_ATTRS: Dict[str, List[str]] = {
-    "QB": [
-        "throw_power",
-        "throw_accuracy_short",
-        "throw_accuracy_mid",
-        "throw_accuracy_deep",
-        "throw_on_run",
-        "pocket_presence",
-        "release_time",
-        "read_progression",
-        "throw_under_pressure",
-    ]
-}
-
-CORE_ATTRS = ["speed", "strength", "agility", "awareness"]
-
-
-def _generate_attribute_caps(position: str) -> Dict[str, int]:
-    attrs = CORE_ATTRS + POSITION_ATTRS.get(position.upper(), [])
-    caps = {}
-    for attr in attrs:
-        base_low = 70 if attr in CORE_ATTRS else 60
-        base_high = 99 if attr in CORE_ATTRS else 95
-        caps[attr] = random.randint(base_low, base_high)
-    return caps
-
-
-@dataclass
-class PlayerDNA:
-    max_attribute_caps: Dict[str, int]
-    development_speed: float
-    regression_rate: float
-    peak_age: int
-    peak_duration: int
-    growth_curve: Dict[int, float]
-    mutations: List[str] = field(default_factory=list)
-
-    def apply_mutation_effects(self) -> None:
-        """Modify attribute caps in-place based on mutations."""
-        for m in self.mutations:
-            details = DNA_MUTATIONS.get(m, {})
-            boosts = details.get("attribute_cap_boosts", {})
-            for group, amt in boosts.items():
-                for attr in list(self.max_attribute_caps.keys()):
-                    if group in attr:
-                        new_val = int(self.max_attribute_caps[attr] * (1 + amt))
-                        self.max_attribute_caps[attr] = min(99, new_val)
-            mult = details.get("dev_speed_multiplier")
-            if mult:
-                self.development_speed = round(self.development_speed * mult, 2)
-
+    # Convenience factory used by Player for compatibility
     @staticmethod
-    def generate_random_dna(position: str) -> "PlayerDNA":
-        dev_speed = round(random.uniform(0.85, 1.15), 2)
-        regression = round(random.uniform(0.85, 1.25), 2)
-        peak_age = int(max(min(random.gauss(27, 2), 32), 22))
-        peak_duration = random.randint(1, 6)
-        growth_curve = generate_growth_curve(
-            min_age=20,
-            max_age=40,
-            peak_age=peak_age,
-            peak_duration=peak_duration,
-        )
-        mutation = []
-        if random.random() <= 0.05:
-            mutation.append(random.choice(list(DNA_MUTATIONS.keys())))
-        caps = _generate_attribute_caps(position)
-        dna = PlayerDNA(
-            max_attribute_caps=caps,
-            development_speed=dev_speed,
-            regression_rate=regression,
-            peak_age=peak_age,
-            peak_duration=peak_duration,
-            growth_curve=growth_curve,
-            mutations=mutation,
-        )
-        if mutation:
-            dna.apply_mutation_effects()
-        return dna
-
-    @classmethod
-    def from_dict(cls, data: Dict) -> "PlayerDNA":
-        return cls(
-            max_attribute_caps=data.get("max_attribute_caps", {}),
-            development_speed=data.get("development_speed", 1.0),
-            regression_rate=data.get("regression_rate", 1.0),
-            peak_age=data.get("peak_age", 26),
-            peak_duration=data.get("peak_duration", 3),
-            growth_curve=data.get("growth_curve", {}),
-            mutations=data.get("mutations", []),
-        )
-
-    def to_dict(self) -> Dict:
-        return {
-            "max_attribute_caps": self.max_attribute_caps,
-            "development_speed": self.development_speed,
-            "regression_rate": self.regression_rate,
-            "peak_age": self.peak_age,
-            "peak_duration": self.peak_duration,
-            "growth_curve": self.growth_curve,
-            "mutations": self.mutations,
-        }
+    def generate_random_dna(position: str | None = None) -> "PlayerDNA":
+        _ = position  # position is unused but kept for API compatibility
+        return PlayerDNA()

--- a/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm/gridiron_gm_pkg/simulation/entities/player.py
@@ -4,16 +4,34 @@ from dataclasses import dataclass, field
 from typing import List, Dict, Optional
 from gridiron_gm.gridiron_gm_pkg.players.player_dna import PlayerDNA
 
+# Generic attributes shared by all players
+CORE_ATTRIBUTES = [
+    "speed",
+    "acceleration",
+    "agility",
+    "strength",
+    "awareness",
+    "iq",
+    "stamina",
+    "toughness",
+    "balance",
+    "discipline",
+    "consistency",
+]
+
+
 @dataclass
 class DevArc:
     type: str
     current_progress: float
     milestones: List[str] = field(default_factory=list)
 
+
 @dataclass
 class AttributeSet:
     core: Dict[str, int] = field(default_factory=dict)
     position_specific: Dict[str, int] = field(default_factory=dict)
+
 
 @dataclass
 class Contract:
@@ -21,8 +39,20 @@ class Contract:
     salary_per_year: int
     bonuses: Dict[str, int] = field(default_factory=dict)
 
+
 class Player:
-    def __init__(self, name, position, age, dob, college, birth_location, jersey_number, overall, potential=None):
+    def __init__(
+        self,
+        name,
+        position,
+        age,
+        dob,
+        college,
+        birth_location,
+        jersey_number,
+        overall,
+        potential=None,
+    ):
         self.id = str(uuid4())
         self.name = name
         self.position = position
@@ -55,10 +85,12 @@ class Player:
         self.passion = None
         self.resilience = None
 
-        # Initialize position-specific attributes dictionary
-        self.position_specific = self.init_position_attributes()
+        # Initialize attribute containers
+        core_attrs = self.init_core_attributes()
+        pos_attrs = self.init_position_attributes()
 
-        self.attributes = AttributeSet(position_specific=self.position_specific)
+        self.position_specific = pos_attrs
+        self.attributes = AttributeSet(core=core_attrs, position_specific=pos_attrs)
         self.dev_arc = DevArc("standard", 0.0)
         self.contract = None
         self.morale = 100
@@ -87,7 +119,7 @@ class Player:
             "gameday": [],
             "physical": [],
             "mental": [],
-            "media": []
+            "media": [],
         }
 
         self.skills = {}
@@ -115,7 +147,16 @@ class Player:
 
         # --- Procedural DNA profile ---
         self.dna = PlayerDNA.generate_random_dna(self.position)
-        self.hidden_caps = self.dna.max_attribute_caps.copy()
+        self.hidden_caps = {
+            k: v["hard_cap"] for k, v in self.dna.attribute_caps.items()
+        }
+        self.scouted_potential = self.dna.scouted_caps.copy()
+
+    def init_core_attributes(self):
+        """Return baseline attribute mapping common to all players."""
+        core = {attr: None for attr in CORE_ATTRIBUTES}
+        core["stamina"] = self.stamina
+        return core
 
     def init_position_attributes(self):
         position = self.position.upper()
@@ -123,69 +164,135 @@ class Player:
 
         if position in ["QB"]:
             attrs = [
-                "throw_power", "throw_accuracy_short", "throw_accuracy_mid", "throw_accuracy_deep",
-                "throw_on_run", "pocket_presence", "release_time", "read_progression", "scramble_tendency", "throwing_footwork",
-                "throw_under_pressure"
+                "throw_power",
+                "throw_accuracy_short",
+                "throw_accuracy_mid",
+                "throw_accuracy_deep",
+                "throw_on_run",
+                "pocket_presence",
+                "release_time",
+                "read_progression",
+                "scramble_tendency",
+                "throwing_footwork",
+                "throw_under_pressure",
             ]
         elif position in ["RB"]:
             attrs = [
-                "ball_carrier_vision", "elusiveness", "break_tackle", "trucking", "carry_security",
-                "pass_block", "route_running", "catching"
+                "ball_carrier_vision",
+                "elusiveness",
+                "break_tackle",
+                "trucking",
+                "carry_security",
+                "pass_block",
+                "route_running",
+                "catching",
             ]
         elif position in ["WR"]:
             attrs = [
-                "catching", "catch_in_traffic", "spectacular_catch", "release",
-                "route_running_short", "route_running_mid", "route_running_deep",
-                "separation", "run_blocking"
+                "catching",
+                "catch_in_traffic",
+                "spectacular_catch",
+                "release",
+                "route_running_short",
+                "route_running_mid",
+                "route_running_deep",
+                "separation",
+                "run_blocking",
             ]
         elif position in ["TE"]:
             attrs = [
-                "catching", "catch_in_traffic", "release", "route_running_short",
-                "route_running_mid", "route_running_deep", "separation",
-                "run_blocking", "pass_block", "lead_blocking"
+                "catching",
+                "catch_in_traffic",
+                "release",
+                "route_running_short",
+                "route_running_mid",
+                "route_running_deep",
+                "separation",
+                "run_blocking",
+                "pass_block",
+                "lead_blocking",
             ]
         elif position in ["LT", "LG", "C", "RG", "RT", "OL"]:
             attrs = [
-                "pass_block", "run_block", "impact_blocking", "block_shed_resistance",
-                "footwork_ol", "lead_blocking"
+                "pass_block",
+                "run_block",
+                "impact_blocking",
+                "block_shed_resistance",
+                "footwork_ol",
+                "lead_blocking",
             ]
         elif position in ["EDGE", "DE"]:
             attrs = [
-                "pass_rush_power", "pass_rush_finesse", "block_shedding", "run_defense",
-                "pursuit_dl", "tackle_dl", "play_recognition", "hands",
-                "hit_power", "strip_ball"
+                "pass_rush_power",
+                "pass_rush_finesse",
+                "block_shedding",
+                "run_defense",
+                "pursuit_dl",
+                "tackle_dl",
+                "play_recognition",
+                "hands",
+                "hit_power",
+                "strip_ball",
             ]
         elif position in ["DT"]:
             attrs = [
-                "block_shedding", "run_defense", "pass_rush_power", "pass_rush_finesse",
-                "tackle_dl", "pursuit_dl", "play_recognition", "hands",
-                "hit_power", "strip_ball"
+                "block_shedding",
+                "run_defense",
+                "pass_rush_power",
+                "pass_rush_finesse",
+                "tackle_dl",
+                "pursuit_dl",
+                "play_recognition",
+                "hands",
+                "hit_power",
+                "strip_ball",
             ]
         elif position in ["MLB", "OLB", "LB"]:
             attrs = [
-                "tackle_lb", "block_shedding", "zone_coverage_lb", "man_coverage_lb",
-                "pass_rush_lb", "pursuit_lb", "play_recognition_lb",
-                "catching", "hit_power", "strip_ball"
+                "tackle_lb",
+                "block_shedding",
+                "zone_coverage_lb",
+                "man_coverage_lb",
+                "pass_rush_lb",
+                "pursuit_lb",
+                "play_recognition_lb",
+                "catching",
+                "hit_power",
+                "strip_ball",
             ]
         elif position in ["CB"]:
             attrs = [
-                "man_coverage", "zone_coverage", "press", "play_recognition_cb",
-                "catching_cb", "tackle_cb", "pursuit_cb",
-                "hit_power", "strip_ball"
+                "man_coverage",
+                "zone_coverage",
+                "press",
+                "play_recognition_cb",
+                "catching_cb",
+                "tackle_cb",
+                "pursuit_cb",
+                "hit_power",
+                "strip_ball",
             ]
         elif position in ["FS", "SS", "S"]:
             attrs = [
-                "zone_coverage_s", "man_coverage_s", "tackle_s", "hit_power",
-                "catching_s", "run_support", "play_recognition_s", "strip_ball"
+                "zone_coverage_s",
+                "man_coverage_s",
+                "tackle_s",
+                "hit_power",
+                "catching_s",
+                "run_support",
+                "play_recognition_s",
+                "strip_ball",
             ]
         elif position in ["K"]:
             attrs = [
-                "kick_power", "kick_accuracy", "kick_consistency", "kick_clutch", "onside_kick_skill"
+                "kick_power",
+                "kick_accuracy",
+                "kick_consistency",
+                "kick_clutch",
+                "onside_kick_skill",
             ]
         elif position in ["P"]:
-            attrs = [
-                "kick_power", "kick_accuracy", "hang_time", "kick_consistency"
-            ]
+            attrs = ["kick_power", "kick_accuracy", "hang_time", "kick_consistency"]
 
         return {attr: None for attr in attrs}
 
@@ -196,14 +303,14 @@ class Player:
     def get_fatigue_rate(self):
         # Base fatigue rate for all players
         base = 0.1
-        
+
         # Increase fatigue rate for positions requiring high physical exertion
         if self.position in ["WR", "CB", "RB", "LB"]:
             base += 0.05
-        
+
         # Adjust fatigue rate based on stamina (lower stamina increases fatigue)
         base *= (100 - self.stamina) / 100
-        
+
     def fatigue_threshold(self):
         """Return the fatigue level at which the player is considered tired."""
 
@@ -360,7 +467,7 @@ class Player:
             "name": self.name,
             "position": self.position,
             "age": self.age,
-            "dob": self.dob.isoformat() if hasattr(self.dob, 'isoformat') else self.dob,
+            "dob": self.dob.isoformat() if hasattr(self.dob, "isoformat") else self.dob,
             "college": self.college,
             "birth_location": self.birth_location,
             "jersey_number": self.jersey_number,
@@ -403,6 +510,10 @@ class Player:
             "passion": self.passion,
             "resilience": self.resilience,
             "position_specific": self.position_specific,
+            "attributes": {
+                "core": self.attributes.core,
+                "position_specific": self.attributes.position_specific,
+            },
             "active_injury_effects": self.active_injury_effects,
             "rookie_year": self.rookie_year,
             "drafted_by": self.drafted_by,
@@ -422,16 +533,22 @@ class Player:
             name=data["name"],
             position=data["position"],
             age=data.get("age", 22),
-            dob=datetime.datetime.fromisoformat(data["dob"]) if isinstance(data["dob"], str) else data["dob"],
+            dob=(
+                datetime.datetime.fromisoformat(data["dob"])
+                if isinstance(data["dob"], str)
+                else data["dob"]
+            ),
             college=data["college"],
             birth_location=data["birth_location"],
             jersey_number=data["jersey_number"],
             overall=data["overall"],
-            potential=data.get("potential")
+            potential=data.get("potential"),
         )
         player.fatigue = data.get("fatigue", 0)
         player.skills = data.get("skills", {})
-        player.traits = data.get("traits", {"training": [], "mental": [], "gameday": [], "media": []})
+        player.traits = data.get(
+            "traits", {"training": [], "mental": [], "gameday": [], "media": []}
+        )
         player.notes = data.get("notes", [])
         player.contract = data.get("contract", None)
         player.experience = data.get("experience", 0)
@@ -465,13 +582,35 @@ class Player:
         player.greed = data.get("greed")
         player.passion = data.get("passion")
         player.resilience = data.get("resilience")
-        player.position_specific = data.get("position_specific", player.position_specific)
+        player.position_specific = data.get(
+            "position_specific", player.position_specific
+        )
         player.active_injury_effects = data.get("active_injury_effects", {})
         player.hidden_caps = data.get("hidden_caps", {})
         player.scouted_potential = data.get("scouted_potential", {})
         player.last_attribute_values = data.get("last_attribute_values", {})
         player.no_growth_years = data.get("no_growth_years", {})
         player.progress_history = data.get("progress_history", {})
+        attrs_data = data.get("attributes")
+        if attrs_data:
+            core = attrs_data.get("core", {})
+            pos = attrs_data.get("position_specific", {})
+            player.attributes = AttributeSet(core=core, position_specific=pos)
+            player.position_specific = pos
+        else:
+            player.position_specific = data.get(
+                "position_specific", player.position_specific
+            )
+            player.attributes = AttributeSet(
+                core=player.init_core_attributes(),
+                position_specific=player.position_specific,
+            )
+
+        # Sync core attribute values if present in save data
+        for attr in CORE_ATTRIBUTES:
+            val = data.get(attr)
+            if val is not None:
+                player.attributes.core[attr] = val
 
         dna_data = data.get("dna")
         if dna_data:
@@ -479,11 +618,19 @@ class Player:
         else:
             player.dna = PlayerDNA.generate_random_dna(player.position)
         if not player.hidden_caps:
-            player.hidden_caps = player.dna.max_attribute_caps.copy()
+            player.hidden_caps = {
+                k: v["hard_cap"] for k, v in player.dna.attribute_caps.items()
+            }
+        if not player.scouted_potential:
+            player.scouted_potential = player.dna.scouted_caps.copy()
         return player
 
+
 def ensure_player_objects(team):
-    from gridiron_gm.gridiron_gm_pkg.simulation.entities.player import Player  # adjust import as needed
+    from gridiron_gm.gridiron_gm_pkg.simulation.entities.player import (
+        Player,
+    )  # adjust import as needed
+
     new_roster = []
     for p in team.roster:
         if isinstance(p, dict):
@@ -491,4 +638,3 @@ def ensure_player_objects(team):
         else:
             new_roster.append(p)
     team.roster = new_roster
-

--- a/tests/test_player_dna.py
+++ b/tests/test_player_dna.py
@@ -11,172 +11,42 @@ def test_player_has_dna_on_creation():
     p = Player("DNA Guy", "QB", 22, "2003-01-01", "U", "USA", 12, 70)
     assert p.dna is not None
     assert p.hidden_caps
+    assert p.scouted_potential
 
 
 def test_mutation_application():
-    dna = PlayerDNA.generate_random_dna("QB")
-    dna.mutations = ["Physical Freak"]
-    dna.max_attribute_caps = {"speed": 90, "strength": 80}
-    dna.apply_mutation_effects()
-    assert dna.max_attribute_caps["speed"] >= 90
-    assert dna.max_attribute_caps["strength"] >= 80
-
-
-def test_generate_player_growth_tables(tmp_path):
-    """Generate sample players and output growth and attribute tables."""
-    import pandas as pd
-    import matplotlib.pyplot as plt
-
-    players = [Player(f"Player {i}", "QB", 22, "2003-01-01", "U", "USA", i, 70) for i in range(5)]
-
-    table_rows = []
-    for p in players:
-        df = pd.DataFrame(sorted(p.dna.growth_curve.items()), columns=["Age", "Multiplier"])
-        df.to_csv(tmp_path / f"{p.id}_growth.csv", index=False)
-        plt.plot(df["Age"], df["Multiplier"], label=p.name)
-        table_rows.append({
-            "Name": p.name,
-            "Mutation": ",".join(p.dna.mutations) if p.dna.mutations else "None",
-            "DevSpeed": p.dna.development_speed,
-            "Regression": p.dna.regression_rate,
-            "PeakAge": p.dna.peak_age,
-        })
-
-    plt.legend()
-    plt.xlabel("Age")
-    plt.ylabel("Growth Multiplier")
-    plt.title("Player DNA Curves")
-    plt.tight_layout()
-    plt.savefig(tmp_path / "growth_curves.png")
-
-    summary = pd.DataFrame(table_rows)
-    summary.to_csv(tmp_path / "player_summary.csv", index=False)
-
-    # Ensure files were written
-    assert (tmp_path / "growth_curves.png").exists()
-    for p in players:
-        assert (tmp_path / f"{p.id}_growth.csv").exists()
-
-
-def test_growth_curve_has_peak_and_decline():
-    dna = PlayerDNA.generate_random_dna("QB")
-    curve = dna.growth_curve
-    ages = sorted(curve)
-    peak = dna.peak_age
-
-    # Ascending portion up to the peak
-    ascending = all(
-        curve[a] <= curve[min(peak, a + 1)] + 0.05 for a in ages if a < peak
-    )
-    # Descending portion after the peak
-    descending = all(
-        curve[a] >= curve[min(ages[-1], a + 1)] - 0.05 for a in ages if a >= peak
-    )
-
-    assert ascending and descending
-
-
-def test_career_progression_simulation(tmp_path):
-    """Simulate career progression for environment groups A/B/C."""
-    import copy
-    import pandas as pd
-    import matplotlib.pyplot as plt
-
-    groups = {
-        "A": {"xp_factor": 1.5},
-        "B": {"xp_factor": 1.0},
-        "C": {"xp_factor": 0.5},
+    dna = PlayerDNA.generate_random_dna()
+    dna.mutation = "Physical Freak"
+    dna.attribute_caps = {
+        "speed": {
+            "current": 80,
+            "soft_cap": 85,
+            "hard_cap": 90,
+            "breakout_history": [],
+        },
+        "strength": {
+            "current": 70,
+            "soft_cap": 80,
+            "hard_cap": 85,
+            "breakout_history": [],
+        },
     }
+    dna.apply_mutation_effects()
+    assert dna.attribute_caps["speed"]["hard_cap"] >= 90
+    assert dna.dev_speed <= 1.25
 
-    # Create base DNA for each group and shallow clone to players
-    for g in groups:
-        groups[g]["dna"] = PlayerDNA.generate_random_dna("QB")
-        groups[g]["players"] = []
-        for i in range(5):
-            p = Player(f"{g}_QB_{i}", "QB", 20, "2005-01-01", "U", "USA", i, 50)
-            p.dna = copy.copy(groups[g]["dna"])
-            p.speed = 50
-            p.throw_power = 50
-            p.awareness = 50
-            groups[g]["players"].append(p)
 
-    log_rows = []
-    for age in range(20, 36):
-        for g, info in groups.items():
-            xp = 100 * info["xp_factor"]
-            for p in info["players"]:
-                growth = p.dna.growth_curve.get(age, 1.0)
-                mult = growth * p.dna.development_speed
-                gain = (xp * mult) / 100.0
-                if growth < 1.0:
-                    gain -= p.dna.regression_rate
+def test_weekly_growth_and_breakout():
+    dna = PlayerDNA()
+    caps = dna.attribute_caps["speed"].copy()
+    dna.apply_weekly_growth()
+    assert dna.attribute_caps["speed"]["current"] >= caps["current"]
+    dna.check_breakout("speed", production_metric=True, snap_share=0.8, week=1)
+    assert dna.attribute_caps["speed"]["current"] >= caps["current"]
 
-                for attr in ["speed", "throw_power", "awareness"]:
-                    cap = p.dna.max_attribute_caps.get(attr, 99)
-                    val = getattr(p, attr) + gain
-                    setattr(p, attr, min(cap, val))
 
-                ovr = round((p.speed + p.throw_power + p.awareness) / 3, 2)
-                log_rows.append(
-                    {
-                        "player_id": p.id,
-                        "group": g,
-                        "age": age,
-                        "ovr": ovr,
-                        "speed": p.speed,
-                        "throw_power": p.throw_power,
-                        "awareness": p.awareness,
-                        "growth_multiplier": round(mult, 3),
-                        "net_gain": round(gain, 3),
-                    }
-                )
-
-    df = pd.DataFrame(log_rows)
-    df.to_csv(tmp_path / "career_log.csv", index=False)
-
-    # OVR progression per group
-    plt.figure()
-    for g in groups:
-        avg_ovr = df[df["group"] == g].groupby("age")["ovr"].mean()
-        plt.plot(avg_ovr.index, avg_ovr.values, label=f"Group {g}")
-    plt.xlabel("Age")
-    plt.ylabel("OVR")
-    plt.legend()
-    plt.title("OVR Progression by Group")
-    plt.tight_layout()
-    plt.savefig(tmp_path / "ovr_by_age.png")
-    plt.close()
-
-    # Attribute growth comparison
-    plt.figure()
-    final_attrs = (
-        df[df["age"] == 35]
-        .groupby("group")[["speed", "throw_power", "awareness"]]
-        .mean()
-    )
-    final_attrs.plot(kind="bar")
-    plt.ylabel("Rating")
-    plt.title("Final Attribute Ratings by Group")
-    plt.tight_layout()
-    plt.savefig(tmp_path / "attr_growth.png")
-    plt.close()
-
-    # DNA growth curves
-    plt.figure()
-    for g, info in groups.items():
-        ages = sorted(info["dna"].growth_curve)
-        vals = [info["dna"].growth_curve[a] for a in ages]
-        plt.plot(ages, vals, label=f"Group {g}")
-    plt.xlabel("Age")
-    plt.ylabel("Multiplier")
-    plt.legend()
-    plt.title("DNA Growth Curves")
-    plt.tight_layout()
-    plt.savefig(tmp_path / "growth_curves_groups.png")
-    plt.close()
-
-    # Basic checks
-    assert len(df) == 240
-    for fn in ["career_log.csv", "ovr_by_age.png", "attr_growth.png", "growth_curves_groups.png"]:
-        assert (tmp_path / fn).exists()
-
+def test_position_attribute_storage():
+    rb = Player("Back", "RB", 22, "2003-01-01", "U", "USA", 25, 70)
+    assert "speed" in rb.attributes.core
+    assert "break_tackle" in rb.attributes.position_specific
+    assert "throw_power" not in rb.attributes.position_specific


### PR DESCRIPTION
## Summary
- revamp `PlayerDNA` with growth/regression arcs, traits, mutations and attribute caps
- assign scouting misestimation caps when creating players
- expose DNA info when loading from save data
- adjust tests to cover new API
- store generic and position attributes for players

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684674a1c2388327befa2a314c433dcb