### PR TITLE
Add player regression system

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -32,6 +32,7 @@ from gridiron_gm_pkg.simulation.systems.game.daily_manager import DailyOperation
 from gridiron_gm_pkg.simulation.systems.player.player_season_progression import (
     evaluate_player_season_progression,
 )
+from gridiron_gm_pkg.simulation.systems.player.player_regression import apply_regression
 from gridiron_gm_pkg.simulation.systems.player.weekly_training import apply_weekly_training
 
 
@@ -551,6 +552,7 @@ class SeasonManager:
                 # Age up
                 if hasattr(player, "age"):
                     player.age += 1
+                    apply_regression(player)
                 # Optional: retire old/severely injured players
                 if hasattr(player, "age") and player.age >= 38:
                     player.retired = True

--- a/gridiron_gm_pkg/simulation/systems/player/player_dna.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_dna.py
@@ -50,6 +50,47 @@ def generate_dev_speed() -> float:
     value = random.normalvariate(0.65, 0.1)
     return max(0.3, min(1.0, round(value, 3)))
 
+# === Regression defaults ===
+DEFAULT_REGRESSION_PROFILE = {
+    "start_age": 30,
+    "rate": 0.04,  # 4% decline per year after start
+    "position_modifier": {
+        "RB": 1.3,
+        "QB": 0.8,
+        "WR": 1.0,
+        "LB": 1.2,
+        "OL": 1.1,
+        "DL": 1.1,
+        "DB": 1.2,
+        "TE": 1.0,
+        "K": 0.5,
+        "P": 0.5,
+    },
+}
+
+ATTRIBUTE_DECAY_TYPE = {
+    # Physical
+    "speed": "physical",
+    "acceleration": "physical",
+    "agility": "physical",
+    "jumping": "physical",
+    "strength": "physical",
+    "stamina": "physical",
+    "toughness": "physical",
+    # Skill
+    "catching": "skill",
+    "tackling": "skill",
+    "blocking": "skill",
+    "route_running": "skill",
+    "throw_power": "skill",
+    "throw_accuracy": "skill",
+    "lead_blocking": "skill",
+    # Mental
+    "awareness": "mental",
+    "iq": "mental",
+    "vision": "mental",
+    "play_recognition": "mental",
+}
 # === Mutation utility functions ===
 # === ATTRIBUTE CAPS STRUCTURE ===
 def generate_attribute_caps(dev_focus: Dict[str, float]) -> Dict[str, Dict]:
@@ -80,7 +121,8 @@ class PlayerDNA:
     """Container for a player's long-term development profile."""
 
     growth_arc: str = field(init=False)
-    regression_profile: str = field(init=False)
+    regression_profile: Dict[str, any] = field(init=False)
+    attribute_decay_type: Dict[str, str] = field(init=False)
     dev_speed: float = field(init=False)
     dev_focus: Dict[str, float] = field(init=False)
     traits: List[str] = field(init=False)
@@ -90,9 +132,8 @@ class PlayerDNA:
 
     def __post_init__(self) -> None:
         self.growth_arc = random.choice(["early", "late", "balanced", "rollercoaster"])
-        self.regression_profile = random.choice(
-            ["early_decline", "late_decline", "injury_decline", "gradual"]
-        )
+        self.regression_profile = DEFAULT_REGRESSION_PROFILE.copy()
+        self.attribute_decay_type = ATTRIBUTE_DECAY_TYPE
         self.dev_speed = generate_dev_speed()
         self.dev_focus = self._generate_dev_focus_weights()
         self.traits = self._assign_traits()
@@ -196,6 +237,7 @@ class PlayerDNA:
         return {
             "growth_arc": self.growth_arc,
             "regression_profile": self.regression_profile,
+            "attribute_decay_type": self.attribute_decay_type,
             "dev_speed": self.dev_speed,
             "dev_focus": self.dev_focus,
             "traits": self.traits,
@@ -210,6 +252,7 @@ class PlayerDNA:
         for field_name in [
             "growth_arc",
             "regression_profile",
+            "attribute_decay_type",
             "dev_speed",
             "dev_focus",
             "traits",

--- a/gridiron_gm_pkg/simulation/systems/player/player_regression.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_regression.py
@@ -1,0 +1,91 @@
+"""Player attribute regression system."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .player_dna import MutationType
+
+# === Decay configuration ===
+attribute_decay_type = {
+    # Physical
+    "speed": "physical",
+    "acceleration": "physical",
+    "agility": "physical",
+    "jumping": "physical",
+    "strength": "physical",
+    "stamina": "physical",
+    "toughness": "physical",
+    # Skill
+    "catching": "skill",
+    "tackling": "skill",
+    "blocking": "skill",
+    "route_running": "skill",
+    "throw_power": "skill",
+    "throw_accuracy": "skill",
+    "lead_blocking": "skill",
+    # Mental
+    "awareness": "mental",
+    "iq": "mental",
+    "vision": "mental",
+    "play_recognition": "mental",
+}
+
+# Multipliers applied to base regression rate
+decay_multipliers = {
+    "physical": 1.0,
+    "skill": 0.6,
+    "mental": 0.3,
+}
+
+# Attributes considered for each position
+valid_attributes_by_position: Dict[str, list[str]] = {
+    "QB": ["throw_power", "throw_accuracy", "awareness", "iq", "agility", "acceleration", "vision"],
+    "RB": ["speed", "acceleration", "agility", "toughness", "awareness", "carrying", "elusiveness", "catching", "stamina"],
+    "WR": ["speed", "acceleration", "agility", "catching", "route_running", "awareness", "jumping", "release"],
+    "TE": ["strength", "blocking", "lead_blocking", "catching", "route_running", "awareness"],
+    "OL": ["strength", "blocking", "lead_blocking", "awareness", "toughness", "footwork_ol"],
+    "DL": ["strength", "tackling", "block_shedding", "awareness", "play_recognition", "pursuit_dl"],
+    "LB": ["speed", "tackling", "awareness", "play_recognition", "strength", "coverage", "block_shedding"],
+    "DB": ["speed", "acceleration", "agility", "awareness", "catching", "coverage", "play_recognition", "jumping"],
+    "K": ["kick_power", "kick_accuracy", "awareness"],
+    "P": ["punt_power", "punt_accuracy", "awareness"],
+}
+
+
+def apply_regression(player) -> None:
+    """Apply end-of-season attribute regression to a player."""
+    age = getattr(player, "age", 0)
+    position = getattr(player, "position", "")
+    dna = getattr(player, "dna", None)
+    if dna is None:
+        return
+    profile = getattr(dna, "regression_profile", {})
+    mutations = getattr(dna, "mutations", [])
+
+    if age < profile.get("start_age", 30):
+        return
+
+    base_rate = profile.get("rate", 0.03)
+    position_factor = profile.get("position_modifier", {}).get(position, 1.0)
+
+    attr_container = getattr(player, "attributes", None)
+    if attr_container is None:
+        return
+    core = getattr(attr_container, "core", {})
+    pos_attrs = getattr(attr_container, "position_specific", {})
+
+    valid = valid_attributes_by_position.get(position, [])
+    containers = [core, pos_attrs]
+
+    for container in containers:
+        for attr, value in container.items():
+            if attr not in valid or value is None:
+                continue
+            decay_type = attribute_decay_type.get(attr, "physical")
+            decay_mult = decay_multipliers.get(decay_type, 1.0)
+            rate = base_rate * position_factor * decay_mult
+            if MutationType.BuiltToLast in mutations:
+                rate *= 0.5
+            new_val = max(0, round(value * (1 - rate), 2))
+            container[attr] = new_val

--- a/tests/test_player_dna.py
+++ b/tests/test_player_dna.py
@@ -6,6 +6,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from gridiron_gm_pkg.simulation.systems.player.player_dna import PlayerDNA, MutationType
+from gridiron_gm_pkg.simulation.systems.player.player_regression import apply_regression
 from gridiron_gm_pkg.simulation.entities.player import Player
 
 
@@ -56,6 +57,23 @@ def test_position_attribute_storage():
     assert "speed" in rb.attributes.core
     assert "break_tackle" in rb.attributes.position_specific
     assert "throw_power" not in rb.attributes.position_specific
+
+
+def test_regression_profile_defaults():
+    dna = PlayerDNA()
+    prof = dna.regression_profile
+    assert isinstance(prof, dict)
+    assert prof.get("start_age") >= 0
+    assert dna.attribute_decay_type.get("speed") == "physical"
+
+
+def test_apply_regression_decreases_values():
+    player = Player("Old", "RB", 31, "1990-01-01", "U", "USA", 22, 70)
+    player.attributes.core["speed"] = 80
+    player.attributes.core["acceleration"] = 80
+    apply_regression(player)
+    assert player.attributes.core["speed"] < 80
+    assert player.attributes.core["acceleration"] < 80
 
 
 def test_dna_long_term_progression(tmp_path):


### PR DESCRIPTION
## Summary
- create `player_regression.py` with regression logic
- expand PlayerDNA with regression profile and decay map
- run regression in `handle_offseason`
- add unit tests for regression features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e68384c7883278ee8e1456b7ed45c