### PR TITLE
Centralize Player core attributes

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/player/daily_training.py
+++ b/gridiron_gm_pkg/simulation/systems/player/daily_training.py
@@ -125,10 +125,13 @@ def log_season_progress_checkpoint(date: Any, all_players: Iterable[Any], checkp
     for player in all_players:
         hist = getattr(player, "progress_history", {})
         snapshot: Dict[str, Any] = {}
-        attrs = getattr(player, "attributes", None)
-        if attrs is not None:
-            snapshot.update(getattr(attrs, "core", {}))
-            snapshot.update(getattr(attrs, "position_specific", {}))
+        if hasattr(player, "get_all_attributes"):
+            snapshot.update(player.get_all_attributes())
+        else:
+            attrs = getattr(player, "attributes", None)
+            if attrs is not None:
+                snapshot.update(getattr(attrs, "core", {}))
+                snapshot.update(getattr(attrs, "position_specific", {}))
         for field, val in player.__dict__.items():
             if field.startswith("_"):
                 continue

--- a/gridiron_gm_pkg/simulation/systems/player/player_weekly_growth.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_weekly_growth.py
@@ -15,6 +15,9 @@ import random
 def _get_training_attributes(player) -> Dict[str, int]:
     """Return combined mapping of attribute names to values for the player."""
 
+    if hasattr(player, "get_all_attributes"):
+        return dict(player.get_all_attributes())
+
     attrs = {}
     attr_container = getattr(player, "attributes", None)
     if attr_container is None:


### PR DESCRIPTION
## Summary
- store core attributes inside `Player.attributes.core`
- expose properties for backward compatibility
- generate caps only for relevant attributes
- add helper methods for fetching all attributes
- update training modules to call `get_all_attributes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f03f267448327a0e09c385a297893