### PR TITLE
Update PlayerDNA tests for new attribute generation

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/player/attribute_generator.py
+++ b/gridiron_gm_pkg/simulation/systems/player/attribute_generator.py
@@ -136,7 +136,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
 }
 
 # Rating caps based on attribute relevance
-RELEVANCE_CAP_RANGES: Dict[str, Tuple[int, int]] = {n
+RELEVANCE_CAP_RANGES: Dict[str, Tuple[int, int]] = {
     "high": (80, 99),
     "medium": (60, 85),
     "low": (20, 45),

--- a/tests/test_player_dna.py
+++ b/tests/test_player_dna.py
@@ -145,12 +145,9 @@ def _simulate_full_career(player_id: str, position: str, years: int = 15):
     clone = PlayerDNA.from_dict(data)
     assert [m.name for m in clone.mutations] == [m.name for m in dna.mutations]
 
-    tmp_player = Player("tmp", position, 22, "2000-01-01", "U", "USA", 0, 60)
-    attrs = {attr: random.randint(65, 75) for attr in tmp_player.get_relevant_attribute_names()}
-    caps = {
-        attr: min(attrs[attr] + random.randint(10, 25), 100)
-        for attr in attrs
-    }
+    from gridiron_gm_pkg.simulation.systems.player import attribute_generator
+
+    attrs, caps = attribute_generator.generate_attributes_for_position(position)
 
     class AttrSet:
         def __init__(self, core: dict):
@@ -164,7 +161,6 @@ def _simulate_full_career(player_id: str, position: str, years: int = 15):
     player.position = position
     player.dna = dna
     player.attributes = AttrSet(attrs)
-    player.get_relevant_attribute_names = tmp_player.get_relevant_attribute_names
 
     base_attrs = attrs.copy()
     arc = dna.career_arc[:years]


### PR DESCRIPTION
## Summary
- fix stray character in attribute generator
- use `attribute_generator.generate_attributes_for_position` in PlayerDNA tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f17572e7883278ba94dd5bc5fa729