### PR TITLE
Add DNA mutation processor

### DIFF
--- a/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm_pkg/simulation/entities/player.py
@@ -236,6 +236,7 @@ class Player:
 
         # --- Procedural DNA profile ---
         self.dna = PlayerDNA.generate_random_dna(self.position)
+        self.mutations = [m.name.lower() for m in self.dna.mutations]
 
         self.generate_caps()
 
@@ -634,6 +635,7 @@ class Player:
             "no_growth_years": self.no_growth_years,
             "progress_history": self.progress_history,
             "dna": self.dna.to_dict() if hasattr(self, "dna") else None,
+            "mutations": self.mutations,
         }
 
     @staticmethod
@@ -713,6 +715,10 @@ class Player:
             player.dna = PlayerDNA.from_dict(dna_data)
         else:
             player.dna = PlayerDNA.generate_random_dna(player.position)
+        player.mutations = data.get(
+            "mutations",
+            [m.name.lower() for m in getattr(player.dna, "mutations", [])],
+        )
         if not player.hidden_caps or not player.scouted_potential:
             player.generate_caps()
         return player

--- a/gridiron_gm_pkg/simulation/systems/player/mutation_processor.py
+++ b/gridiron_gm_pkg/simulation/systems/player/mutation_processor.py
@@ -1,0 +1,61 @@
+"""Apply DNA mutation effects to player attributes at creation time."""
+from __future__ import annotations
+
+import random
+from typing import Dict, List
+
+from gridiron_gm_pkg.simulation.entities.player import Player
+
+# Mapping of mutation names to their effects
+MUTATION_EFFECTS = {
+    "physical_freak": {
+        "attributes": ["speed", "acceleration", "agility", "strength"],
+        "cap_boost_range": (3, 10),
+        "start_boost_range": (2, 8),
+    },
+    "durable": {
+        "attributes": ["toughness"],
+        "cap_boost_range": (2, 5),
+        "start_boost_range": (2, 5),
+        "injury_multiplier": 0.9,
+        "recovery_speed_bonus": 0.15,
+    },
+    "fragile": {
+        "attributes": ["toughness"],
+        "cap_boost_range": (-5, -2),
+        "start_boost_range": (-10, -5),
+        "injury_multiplier": 1.25,
+    },
+}
+
+
+def apply_mutations(player: Player, attributes: Dict[str, int], caps: Dict[str, int]) -> None:
+    """Apply mutation boosts to ``attributes`` and ``caps`` in-place."""
+    if not getattr(player, "mutations", None):
+        return
+
+    for mutation in player.mutations:
+        effects = MUTATION_EFFECTS.get(mutation)
+        if not effects:
+            continue
+
+        cap_low, cap_high = effects.get("cap_boost_range", (0, 0))
+        start_low, start_high = effects.get("start_boost_range", (0, 0))
+        for attr in effects.get("attributes", []):
+            if attr not in caps:
+                continue
+            cap_boost = random.randint(cap_low, cap_high)
+            caps[attr] = max(0, min(99, caps[attr] + cap_boost))
+            start_boost = random.randint(start_low, start_high)
+            new_val = attributes.get(attr, 0) + start_boost
+            attributes[attr] = max(0, min(caps[attr], new_val))
+
+        # Store any system-level effects on the player's DNA profile
+        if hasattr(player, "dna"):
+            if "injury_multiplier" in effects:
+                base = getattr(player.dna, "injury_multiplier", 1.0)
+                player.dna.injury_multiplier = base * effects["injury_multiplier"]
+            if "recovery_speed_bonus" in effects:
+                base = getattr(player.dna, "recovery_speed_bonus", 0.0)
+                player.dna.recovery_speed_bonus = base + effects["recovery_speed_bonus"]
+

--- a/gridiron_gm_pkg/simulation/systems/player/player_dna.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_dna.py
@@ -136,6 +136,8 @@ class PlayerDNA:
     mutations: List[MutationType] = field(init=False)
     attribute_caps: Dict[str, Dict] = field(init=False)
     scouted_caps: Dict[str, int] = field(init=False)
+    injury_multiplier: float = field(init=False)
+    recovery_speed_bonus: float = field(init=False)
 
     def __post_init__(self) -> None:
         self.rise_duration = random.randint(1, 6)
@@ -153,6 +155,8 @@ class PlayerDNA:
         self.mutations = assign_mutations()
         self.attribute_caps = generate_attribute_caps(self.dev_focus)
         self.scouted_caps = self._generate_scouted_caps()
+        self.injury_multiplier = 1.0
+        self.recovery_speed_bonus = 0.0
 
     def generate_procedural_arc(self, total_years: int = 25) -> List[float]:
         """Return an annual multiplier curve representing the player's career trajectory."""
@@ -273,6 +277,8 @@ class PlayerDNA:
             "mutations": [m.name for m in self.mutations],
             "attribute_caps": self.attribute_caps,
             "scouted_caps": self.scouted_caps,
+            "injury_multiplier": self.injury_multiplier,
+            "recovery_speed_bonus": self.recovery_speed_bonus,
         }
 
     @classmethod
@@ -292,6 +298,8 @@ class PlayerDNA:
             "traits",
             "attribute_caps",
             "scouted_caps",
+            "injury_multiplier",
+            "recovery_speed_bonus",
         ]:
             setattr(obj, field_name, data.get(field_name))
         obj.mutations = [MutationType[m] for m in data.get("mutations", [])]

--- a/tests/test_mutation_processor.py
+++ b/tests/test_mutation_processor.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm_pkg.simulation.entities.player import Player
+from gridiron_gm_pkg.simulation.systems.player import attribute_generator
+from gridiron_gm_pkg.simulation.systems.player.mutation_processor import apply_mutations
+
+
+def test_apply_mutations_increases_caps_and_values():
+    player = Player("Mutant", "RB", 22, "2003-01-01", "U", "USA", 1, 70)
+    player.mutations = ["physical_freak", "durable"]
+    attrs, caps = attribute_generator.generate_attributes_for_position("RB")
+    # Add toughness since attribute generator doesn't provide it
+    caps["toughness"] = 70
+    attrs["toughness"] = 65
+
+    old_speed_cap = caps["speed"]
+    old_speed = attrs["speed"]
+    old_tough_cap = caps["toughness"]
+    old_tough = attrs["toughness"]
+
+    apply_mutations(player, attrs, caps)
+
+    assert caps["speed"] >= old_speed_cap
+    assert attrs["speed"] >= old_speed
+    assert caps["speed"] <= 99
+    assert attrs["speed"] <= caps["speed"]
+
+    assert caps["toughness"] >= old_tough_cap
+    assert attrs["toughness"] >= old_tough
+    assert player.dna.injury_multiplier < 1.0
+
+
+def test_fragile_decreases_caps():
+    player = Player("Glass", "RB", 22, "2003-01-01", "U", "USA", 2, 70)
+    player.mutations = ["fragile"]
+    attrs, caps = attribute_generator.generate_attributes_for_position("RB")
+    caps["toughness"] = 70
+    attrs["toughness"] = 65
+
+    old_cap = caps["toughness"]
+    apply_mutations(player, attrs, caps)
+
+    assert caps["toughness"] <= old_cap
+    assert player.dna.injury_multiplier > 1.0


### PR DESCRIPTION
## Summary
- implement player mutation processor for attribute boosts
- store mutations on Player instances and add system effects in PlayerDNA
- expose new fields in serialization helpers
- add tests covering mutation processing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f380cc27483278f16214f38440359