### PR TITLE
Add QB archetype evaluation function

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/player/archetype_evaluator.py
+++ b/gridiron_gm_pkg/simulation/systems/player/archetype_evaluator.py
@@ -8,6 +8,47 @@ used by scouting screens or season wrap up reports.
 from typing import Any, Dict
 
 
+# -- QB Archetype definitions used by ``evaluate_qb_archetype`` --
+QB_ARCHETYPES: Dict[str, Dict[str, float]] = {
+    "Pocket Passer": {
+        "throw_accuracy_short": 1.0,
+        "throw_accuracy_medium": 1.0,
+        "awareness": 0.9,
+        "iq": 0.8,
+        "speed": 0.2,
+        "toughness": 0.6,
+    },
+    "Scrambler": {
+        "speed": 1.0,
+        "acceleration": 0.9,
+        "agility": 0.8,
+        "throw_on_run": 0.6,
+        "throw_accuracy_short": 0.5,
+    },
+    "Gunslinger": {
+        "throw_power": 1.0,
+        "throw_accuracy_deep": 0.9,
+        "throw_on_run": 0.6,
+        "iq": 0.5,
+        "discipline": 0.3,
+    },
+    "Field General": {
+        "iq": 1.0,
+        "awareness": 1.0,
+        "throw_accuracy_short": 0.8,
+        "discipline": 0.7,
+        "toughness": 0.6,
+    },
+    "Dual-Threat": {
+        "speed": 0.8,
+        "throw_power": 0.8,
+        "throw_on_run": 0.8,
+        "acceleration": 0.7,
+        "throw_accuracy_deep": 0.7,
+    },
+}
+
+
 def evaluate_archetype(player: Any, stats: Dict[str, int], attributes: Dict[str, int]) -> str:
     """Return a short archetype description based on attributes and stats.
 
@@ -89,3 +130,37 @@ def evaluate_archetype(player: Any, stats: Dict[str, int], attributes: Dict[str,
 
     # Fallback
     return "Raw Prospect"
+
+
+def evaluate_qb_archetype(attributes: Dict[str, int]) -> str:
+    """Return the most likely QB archetype based on weighted attributes.
+
+    Parameters
+    ----------
+    attributes:
+        Mapping of attribute ratings for a quarterback. Values should range
+        from 20 to 99.
+
+    Returns
+    -------
+    str
+        The archetype with the highest weighted score.
+    """
+
+    def norm(val: int) -> float:
+        # Clamp and normalize the attribute rating to ``0-1``.
+        return max(0.0, min((val - 20) / 79, 1.0))
+
+    best_type = ""
+    best_score = float("-inf")
+
+    for archetype, profile in QB_ARCHETYPES.items():
+        score = 0.0
+        for attr, weight in profile.items():
+            if attr in attributes:
+                score += norm(int(attributes[attr])) * weight
+        if score > best_score:
+            best_score = score
+            best_type = archetype
+
+    return best_type

--- a/tests/test_qb_archetype.py
+++ b/tests/test_qb_archetype.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm_pkg.simulation.systems.player.archetype_evaluator import evaluate_qb_archetype
+
+
+def test_pocket_passer():
+    attrs = {
+        "throw_accuracy_short": 90,
+        "throw_accuracy_medium": 88,
+        "awareness": 85,
+        "iq": 90,
+        "speed": 60,
+        "toughness": 70,
+    }
+    assert evaluate_qb_archetype(attrs) == "Pocket Passer"
+
+
+def test_dual_threat():
+    attrs = {
+        "speed": 92,
+        "acceleration": 88,
+        "agility": 80,
+        "throw_on_run": 85,
+        "throw_power": 90,
+        "throw_accuracy_deep": 85,
+    }
+    assert evaluate_qb_archetype(attrs) == "Dual-Threat"
+
+
+def test_gunslinger():
+    attrs = {
+        "throw_power": 95,
+        "throw_accuracy_deep": 90,
+        "throw_on_run": 80,
+        "iq": 75,
+        "discipline": 60,
+    }
+    assert evaluate_qb_archetype(attrs) == "Gunslinger"
+


### PR DESCRIPTION
## Summary
- extend `archetype_evaluator` with QB archetype profiles and a weighted matching function
- add unit tests covering multiple quarterback archetypes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3f170a0c83279ead93b994dba34a