### PR TITLE
Add RB archetype evaluator

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/player/archetype_evaluator.py
+++ b/gridiron_gm_pkg/simulation/systems/player/archetype_evaluator.py
@@ -8,6 +8,86 @@ used by scouting screens or season wrap up reports.
 from typing import Any, Dict
 
 
+# -- QB Archetype definitions used by ``evaluate_qb_archetype`` --
+QB_ARCHETYPES: Dict[str, Dict[str, float]] = {
+    "Pocket Passer": {
+        "throw_accuracy_short": 1.0,
+        "throw_accuracy_medium": 1.0,
+        "awareness": 0.9,
+        "iq": 0.8,
+        "speed": 0.2,
+        "toughness": 0.6,
+    },
+    "Scrambler": {
+        "speed": 1.0,
+        "acceleration": 0.9,
+        "agility": 0.8,
+        "throw_on_run": 0.6,
+        "throw_accuracy_short": 0.5,
+    },
+    "Gunslinger": {
+        "throw_power": 1.0,
+        "throw_accuracy_deep": 0.9,
+        "throw_on_run": 0.6,
+        "iq": 0.5,
+        "discipline": 0.3,
+    },
+    "Field General": {
+        "iq": 1.0,
+        "awareness": 1.0,
+        "throw_accuracy_short": 0.8,
+        "discipline": 0.7,
+        "toughness": 0.6,
+    },
+    "Dual-Threat": {
+        "speed": 0.8,
+        "throw_power": 0.8,
+        "throw_on_run": 0.8,
+        "acceleration": 0.7,
+        "throw_accuracy_deep": 0.7,
+    },
+}
+
+
+# -- RB Archetype definitions used by ``evaluate_rb_archetype`` --
+RB_ARCHETYPES: Dict[str, Dict[str, float]] = {
+    "Power Back": {
+        "trucking": 1.0,
+        "strength": 0.9,
+        "break_tackle": 0.9,
+        "carry_security": 0.8,
+        "speed": 0.5,
+    },
+    "Elusive Back": {
+        "elusiveness": 1.0,
+        "agility": 0.95,
+        "acceleration": 0.9,
+        "speed": 0.85,
+        "balance": 0.7,
+    },
+    "Receiving Back": {
+        "catching": 1.0,
+        "route_running": 0.9,
+        "acceleration": 0.8,
+        "elusiveness": 0.7,
+        "awareness": 0.6,
+    },
+    "Workhorse": {
+        "carry_security": 1.0,
+        "stamina": 0.9,
+        "toughness": 0.8,
+        "speed": 0.7,
+        "break_tackle": 0.6,
+    },
+    "Speed Back": {
+        "speed": 1.0,
+        "acceleration": 0.95,
+        "elusiveness": 0.8,
+        "agility": 0.75,
+    },
+}
+
+
 def evaluate_archetype(player: Any, stats: Dict[str, int], attributes: Dict[str, int]) -> str:
     """Return a short archetype description based on attributes and stats.
 
@@ -89,3 +169,71 @@ def evaluate_archetype(player: Any, stats: Dict[str, int], attributes: Dict[str,
 
     # Fallback
     return "Raw Prospect"
+
+
+def evaluate_qb_archetype(attributes: Dict[str, int]) -> str:
+    """Return the most likely QB archetype based on weighted attributes.
+
+    Parameters
+    ----------
+    attributes:
+        Mapping of attribute ratings for a quarterback. Values should range
+        from 20 to 99.
+
+    Returns
+    -------
+    str
+        The archetype with the highest weighted score.
+    """
+
+    def norm(val: int) -> float:
+        # Clamp and normalize the attribute rating to ``0-1``.
+        return max(0.0, min((val - 20) / 79, 1.0))
+
+    best_type = ""
+    best_score = float("-inf")
+
+    for archetype, profile in QB_ARCHETYPES.items():
+        score = 0.0
+        for attr, weight in profile.items():
+            if attr in attributes:
+                score += norm(int(attributes[attr])) * weight
+        if score > best_score:
+            best_score = score
+            best_type = archetype
+
+    return best_type
+
+
+def evaluate_rb_archetype(attributes: Dict[str, int]) -> str:
+    """Return the most likely RB archetype based on weighted attributes.
+
+    Parameters
+    ----------
+    attributes:
+        Mapping of attribute ratings for a running back. Values should range
+        from 20 to 99.
+
+    Returns
+    -------
+    str
+        The archetype with the highest weighted score.
+    """
+
+    def norm(val: int) -> float:
+        # Clamp and normalize the attribute rating to ``0-1``.
+        return max(0.0, min((val - 20) / 79, 1.0))
+
+    best_type = ""
+    best_score = float("-inf")
+
+    for archetype, profile in RB_ARCHETYPES.items():
+        score = 0.0
+        for attr, weight in profile.items():
+            if attr in attributes:
+                score += norm(int(attributes[attr])) * weight
+        if score > best_score:
+            best_score = score
+            best_type = archetype
+
+    return best_type

--- a/tests/test_qb_archetype.py
+++ b/tests/test_qb_archetype.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm_pkg.simulation.systems.player.archetype_evaluator import evaluate_qb_archetype
+
+
+def test_pocket_passer():
+    attrs = {
+        "throw_accuracy_short": 90,
+        "throw_accuracy_medium": 88,
+        "awareness": 85,
+        "iq": 90,
+        "speed": 60,
+        "toughness": 70,
+    }
+    assert evaluate_qb_archetype(attrs) == "Pocket Passer"
+
+
+def test_dual_threat():
+    attrs = {
+        "speed": 92,
+        "acceleration": 88,
+        "agility": 80,
+        "throw_on_run": 85,
+        "throw_power": 90,
+        "throw_accuracy_deep": 85,
+    }
+    assert evaluate_qb_archetype(attrs) == "Dual-Threat"
+
+
+def test_gunslinger():
+    attrs = {
+        "throw_power": 95,
+        "throw_accuracy_deep": 90,
+        "throw_on_run": 80,
+        "iq": 75,
+        "discipline": 60,
+    }
+    assert evaluate_qb_archetype(attrs) == "Gunslinger"
+

--- a/tests/test_rb_archetype.py
+++ b/tests/test_rb_archetype.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gridiron_gm_pkg.simulation.systems.player.archetype_evaluator import evaluate_rb_archetype
+
+
+def test_speed_back():
+    attrs = {
+        "speed": 98,
+        "acceleration": 95,
+    }
+    assert evaluate_rb_archetype(attrs) == "Speed Back"
+
+
+def test_power_back():
+    attrs = {
+        "trucking": 92,
+        "strength": 90,
+        "break_tackle": 89,
+        "carry_security": 85,
+        "speed": 72,
+    }
+    assert evaluate_rb_archetype(attrs) == "Power Back"
+
+
+def test_receiving_back():
+    attrs = {
+        "catching": 90,
+        "route_running": 88,
+        "acceleration": 86,
+        "elusiveness": 80,
+        "awareness": 82,
+    }
+    assert evaluate_rb_archetype(attrs) == "Receiving Back"


### PR DESCRIPTION
## Summary
- extend archetype evaluator with RB archetype profiles and scoring logic
- add unit tests for Speed Back, Power Back and Receiving Back

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f3f170a0c83279ead93b994dba34a