### PR TITLE
Implement return_skill attribute across player systems

### DIFF
--- a/gridiron_gm_pkg/config/training_catalog.py
+++ b/gridiron_gm_pkg/config/training_catalog.py
@@ -518,6 +518,11 @@ TRAINING_CATALOG = {
         },
         "injury_chance": 0.001,
     },
+    "Return Specialist Drill": {
+        "positions": ["WR", "RB", "CB", "S"],
+        "attribute_weights": {"return_skill": 1.0, "speed": 0.4},
+        "injury_chance": 0.003,
+    },
 
     # === General / Team-Wide ===
     "Weight Room": {

--- a/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm_pkg/simulation/entities/player.py
@@ -19,6 +19,7 @@ CORE_ATTRIBUTES = [
     "consistency",
     "tackling",
     "catching",
+    "return_skill",
 ]
 
 
@@ -143,6 +144,14 @@ class Player:
     @consistency.setter
     def consistency(self, value: int) -> None:
         self._set_core_attr("consistency", value)
+
+    @property
+    def return_skill(self) -> Optional[int]:
+        return self._get_core_attr("return_skill")
+
+    @return_skill.setter
+    def return_skill(self, value: int) -> None:
+        self._set_core_attr("return_skill", value)
     def __init__(
         self,
         name,
@@ -246,6 +255,7 @@ class Player:
         core["stamina"] = 80
         core["tackling"] = 40
         core["catching"] = 40
+        core["return_skill"] = 20
         return core
 
     def init_position_attributes(self):

--- a/gridiron_gm_pkg/simulation/systems/player/archetype_evaluator.py
+++ b/gridiron_gm_pkg/simulation/systems/player/archetype_evaluator.py
@@ -85,6 +85,21 @@ RB_ARCHETYPES: Dict[str, Dict[str, float]] = {
         "elusiveness": 0.8,
         "agility": 0.75,
     },
+    "Return Specialist": {
+        "return_skill": 1.0,
+        "speed": 0.9,
+        "agility": 0.8,
+    },
+}
+
+# -- WR Archetype definitions used by ``evaluate_wr_archetype`` --
+WR_ARCHETYPES: Dict[str, Dict[str, float]] = {
+    "Return Specialist": {"return_skill": 1.0, "speed": 0.9, "agility": 0.8},
+}
+
+# -- CB Archetype definitions used by ``evaluate_cb_archetype`` --
+CB_ARCHETYPES: Dict[str, Dict[str, float]] = {
+    "Return Specialist": {"return_skill": 1.0, "speed": 0.9, "agility": 0.8},
 }
 
 
@@ -228,6 +243,48 @@ def evaluate_rb_archetype(attributes: Dict[str, int]) -> str:
     best_score = float("-inf")
 
     for archetype, profile in RB_ARCHETYPES.items():
+        score = 0.0
+        for attr, weight in profile.items():
+            if attr in attributes:
+                score += norm(int(attributes[attr])) * weight
+        if score > best_score:
+            best_score = score
+            best_type = archetype
+
+    return best_type
+
+
+def evaluate_wr_archetype(attributes: Dict[str, int]) -> str:
+    """Return the most likely WR archetype based on weighted attributes."""
+
+    def norm(val: int) -> float:
+        return max(0.0, min((val - 20) / 79, 1.0))
+
+    best_type = ""
+    best_score = float("-inf")
+
+    for archetype, profile in WR_ARCHETYPES.items():
+        score = 0.0
+        for attr, weight in profile.items():
+            if attr in attributes:
+                score += norm(int(attributes[attr])) * weight
+        if score > best_score:
+            best_score = score
+            best_type = archetype
+
+    return best_type
+
+
+def evaluate_cb_archetype(attributes: Dict[str, int]) -> str:
+    """Return the most likely CB archetype based on weighted attributes."""
+
+    def norm(val: int) -> float:
+        return max(0.0, min((val - 20) / 79, 1.0))
+
+    best_type = ""
+    best_score = float("-inf")
+
+    for archetype, profile in CB_ARCHETYPES.items():
         score = 0.0
         for attr, weight in profile.items():
             if attr in attributes:

--- a/gridiron_gm_pkg/simulation/systems/player/attribute_generator.py
+++ b/gridiron_gm_pkg/simulation/systems/player/attribute_generator.py
@@ -20,6 +20,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "awareness": "medium",
         "catching": "low",
         "tackling": "low",
+        "return_skill": "very_low",
     },
     "RB": {
         "speed": "high",
@@ -34,6 +35,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "iq": "medium",
         "awareness": "medium",
         "tackling": "low",
+        "return_skill": "medium",
     },
     "WR": {
         "speed": "high",
@@ -45,6 +47,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "iq": "medium",
         "awareness": "medium",
         "tackling": "low",
+        "return_skill": "medium",
     },
     "TE": {
         "catching": "high",
@@ -56,6 +59,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "iq": "medium",
         "awareness": "medium",
         "tackling": "low",
+        "return_skill": "very_low",
     },
     "OL": {
         "blocking": "high",
@@ -66,6 +70,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "speed": "low",
         "catching": "low",
         "tackling": "low",
+        "return_skill": "very_low",
     },
     "EDGE": {
         "pass_rush": "high",
@@ -76,6 +81,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "iq": "medium",
         "awareness": "medium",
         "catching": "low",
+        "return_skill": "very_low",
     },
     "DL": {
         "strength": "high",
@@ -87,6 +93,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "awareness": "medium",
         "catching": "low",
         "tackling": "high",
+        "return_skill": "very_low",
     },
     "LB": {
         "tackling": "high",
@@ -98,6 +105,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "iq": "high",
         "awareness": "high",
         "catching": "medium",
+        "return_skill": "low",
     },
     "CB": {
         "speed": "high",
@@ -108,6 +116,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "pass_rush": "low",
         "iq": "medium",
         "awareness": "high",
+        "return_skill": "medium",
     },
     "S": {
         "coverage": "high",
@@ -116,6 +125,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "catching": "medium",
         "iq": "medium",
         "awareness": "high",
+        "return_skill": "low",
     },
     "K": {
         "kick_power": "high",
@@ -124,6 +134,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "awareness": "medium",
         "catching": "low",
         "tackling": "low",
+        "return_skill": "very_low",
     },
     "P": {
         "punt_power": "high",
@@ -132,6 +143,7 @@ POSITION_RELEVANCE: Dict[str, Dict[str, str]] = {
         "awareness": "medium",
         "catching": "low",
         "tackling": "low",
+        "return_skill": "very_low",
     },
 }
 
@@ -140,6 +152,7 @@ RELEVANCE_CAP_RANGES: Dict[str, Tuple[int, int]] = {
     "high": (80, 99),
     "medium": (60, 85),
     "low": (20, 45),
+    "very_low": (20, 40),
 }
 
 # Starting attribute values based on relevance
@@ -147,6 +160,7 @@ RELEVANCE_GEN_RANGES: Dict[str, Tuple[int, int]] = {
     "high": (70, 90),
     "medium": (55, 75),
     "low": (15, 40),
+    "very_low": (10, 35),
 }
 
 def bell_curve_sample(mean: float, std_dev: float, min_val: int, max_val: int) -> int:

--- a/gridiron_gm_pkg/simulation/systems/player/player_dna.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_dna.py
@@ -86,6 +86,7 @@ ATTRIBUTE_DECAY_TYPE = {
     "throw_power": "skill",
     "throw_accuracy": "skill",
     "lead_blocking": "skill",
+    "return_skill": "skill",
     # Mental
     "awareness": "mental",
     "iq": "mental",
@@ -104,6 +105,7 @@ def generate_attribute_caps(dev_focus: Dict[str, float]) -> Dict[str, Dict]:
         "tackle",
         "catching",
         "route_running_short",
+        "return_skill",
     ]:
         base = random.randint(70, 90)
         soft_cap = int(base + random.randint(2, 5))

--- a/gridiron_gm_pkg/simulation/systems/player/player_regression.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_regression.py
@@ -24,6 +24,7 @@ attribute_decay_type = {
     "throw_power": "skill",
     "throw_accuracy": "skill",
     "lead_blocking": "skill",
+    "return_skill": "skill",
     # Mental
     "awareness": "mental",
     "iq": "mental",
@@ -41,13 +42,13 @@ decay_multipliers = {
 # Attributes considered for each position
 valid_attributes_by_position: Dict[str, list[str]] = {
     "QB": ["throw_power", "throw_accuracy", "awareness", "iq", "agility", "acceleration", "vision"],
-    "RB": ["speed", "acceleration", "agility", "toughness", "awareness", "carrying", "elusiveness", "catching", "stamina"],
-    "WR": ["speed", "acceleration", "agility", "catching", "route_running", "awareness", "jumping", "release"],
+    "RB": ["speed", "acceleration", "agility", "toughness", "awareness", "carrying", "elusiveness", "catching", "stamina", "return_skill"],
+    "WR": ["speed", "acceleration", "agility", "catching", "route_running", "awareness", "jumping", "release", "return_skill"],
     "TE": ["strength", "blocking", "lead_blocking", "catching", "route_running", "awareness"],
     "OL": ["strength", "blocking", "lead_blocking", "awareness", "toughness", "footwork_ol"],
     "DL": ["strength", "tackling", "block_shedding", "awareness", "play_recognition", "pursuit_dl"],
     "LB": ["speed", "tackling", "awareness", "play_recognition", "strength", "coverage", "block_shedding"],
-    "DB": ["speed", "acceleration", "agility", "awareness", "catching", "coverage", "play_recognition", "jumping"],
+    "DB": ["speed", "acceleration", "agility", "awareness", "catching", "coverage", "play_recognition", "jumping", "return_skill"],
     "K": ["kick_power", "kick_accuracy", "awareness"],
     "P": ["punt_power", "punt_accuracy", "awareness"],
 }

--- a/tests/test_attribute_generator.py
+++ b/tests/test_attribute_generator.py
@@ -34,6 +34,8 @@ def test_generator_returns_values(pos):
     for base_attr in ["iq", "awareness", "tackling", "catching"]:
         assert base_attr in attrs
         assert base_attr in caps
+    assert "return_skill" in attrs
+    assert "return_skill" in caps
     for attr, value in attrs.items():
         assert attr in caps
         assert value <= caps[attr]


### PR DESCRIPTION
## Summary
- add `return_skill` to Player core attributes with property helpers
- generate `return_skill` in attribute generator with new relevance level
- support new attribute in DNA caps and regression rules
- include return skill drill in training catalog
- extend archetype evaluator with return specialist profiles
- update tests for new attribute

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4708f93c8327a3c43d3b50df52f0