### PR TITLE
Enable deterministic progression

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/player/player_progression.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_progression.py
@@ -28,6 +28,7 @@ def progress_player(
     player: Player,
     xp_gains: Dict[str, float] | None = None,
     coach_quality: float = 1.0,
+    rng: random.Random | None = None,
 ) -> Player:
     """Update a player's attributes using their DNA growth curve.
 
@@ -39,6 +40,10 @@ def progress_player(
         Optional mapping of attribute names to weekly XP earned from
         training or in-game performance.
 
+    rng:
+        Optional ``random.Random`` instance used to introduce noise. Providing a
+        seeded generator allows deterministic results for testing.
+
     Returns
     -------
     Player
@@ -46,6 +51,7 @@ def progress_player(
     """
 
     xp_gains = xp_gains or {}
+    rng = rng or random
     attrs = getattr(player, "attributes", None)
     dna = getattr(player, "dna", None)
     if attrs is None or dna is None:
@@ -77,7 +83,7 @@ def progress_player(
         growth = gain * arc_mult * dev_speed * quality_mod
         if current >= soft_cap:
             growth *= 0.25
-        growth *= random.uniform(1.0 + NOISE_RANGE[0], 1.0 + NOISE_RANGE[1])
+        growth *= rng.uniform(1.0 + NOISE_RANGE[0], 1.0 + NOISE_RANGE[1])
         container[attr] = round(_clamp(current + growth), 2)
 
     return player

--- a/tests/test_player_progression.py
+++ b/tests/test_player_progression.py
@@ -1,0 +1,41 @@
+import random
+
+from gridiron_gm_pkg.simulation.systems.player.player_progression import progress_player
+
+
+class DummyAttrs:
+    def __init__(self, core):
+        self.core = core
+        self.position_specific = {}
+
+
+class DummyDNA:
+    def __init__(self):
+        self.dev_speed = 1.0
+        self.career_arc = [1.0]
+        self.attribute_caps = {"speed": {"current": 50, "soft_cap": 60, "hard_cap": 90}}
+
+
+def make_player():
+    player = type("P", (), {})()
+    player.attributes = DummyAttrs({"speed": 50})
+    player.dna = DummyDNA()
+    player.hidden_caps = {"speed": 90}
+    player.experience = 0
+    player.get_relevant_attribute_names = lambda: ["speed"]
+    return player
+
+
+def test_progress_player_deterministic_rng():
+    xp = {"speed": 5.0}
+    rng1 = random.Random(42)
+    p1 = make_player()
+    progress_player(p1, xp, rng=rng1)
+    result1 = p1.attributes.core["speed"]
+
+    rng2 = random.Random(42)
+    p2 = make_player()
+    progress_player(p2, xp, rng=rng2)
+    result2 = p2.attributes.core["speed"]
+
+    assert result1 == result2


### PR DESCRIPTION
## Summary
- allow custom RNG for player progression
- add tests for deterministic progression

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f72828a2883279f7c9483a7fc155d