### PR TITLE
Implement weekly player update step

### DIFF
--- a/gridiron_gm_pkg/simulation/entities/team.py
+++ b/gridiron_gm_pkg/simulation/entities/team.py
@@ -161,3 +161,10 @@ class Team:
 
     def __repr__(self) -> str:
         return f"{self.team_name} | Roster Size: {len(self.players)}"
+
+    def get_coach_quality(self) -> float:
+        """Return the team's coaching quality rating."""
+        try:
+            return float(getattr(self, "coach_quality", 1.0))
+        except (TypeError, ValueError):
+            return 1.0

--- a/gridiron_gm_pkg/simulation/systems/game/season_manager.py
+++ b/gridiron_gm_pkg/simulation/systems/game/season_manager.py
@@ -34,6 +34,7 @@ from gridiron_gm_pkg.simulation.systems.player.player_season_progression import 
     evaluate_player_season_progression,
 )
 from gridiron_gm_pkg.simulation.systems.player.player_regression import apply_regression
+from gridiron_gm_pkg.simulation.systems.player.player_weekly_update import advance_player_week
 from gridiron_gm_pkg.simulation.systems.player.weekly_training import apply_weekly_training
 
 
@@ -325,6 +326,11 @@ class SeasonManager:
             plan = getattr(getattr(team, "training_plan", {}), "get", lambda w: None)(just_ended_week)
             if plan:
                 apply_training_plan(team, plan, just_ended_week)
+
+            coach_quality = team.get_coach_quality() if hasattr(team, "get_coach_quality") else 1.0
+            for player in getattr(team, "roster", []):
+                xp_gains = getattr(getattr(player, "training_log", {}), "get", lambda w: {})(just_ended_week)
+                advance_player_week(player, xp_gains, coach_quality)
 
             # Call fatigue accumulation hook (empty list for heavy_usage_players for now)
             accumulate_season_fatigue_for_team(team, [])

--- a/gridiron_gm_pkg/simulation/systems/player/player_weekly_update.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_weekly_update.py
@@ -1,0 +1,10 @@
+from gridiron_gm_pkg.simulation.entities.player import Player
+from gridiron_gm_pkg.simulation.systems.player.player_progression import progress_player
+from gridiron_gm_pkg.simulation.systems.player.player_regression import apply_regression
+
+
+def advance_player_week(player: Player, xp_gains: dict, coach_quality: float, rng=None):
+    """Apply weekly progression and regression to a player."""
+    player = progress_player(player, xp_gains, coach_quality, rng)
+    player = apply_regression(player, player.age, rng)
+    return player

--- a/tests/test_player_weekly_update.py
+++ b/tests/test_player_weekly_update.py
@@ -1,0 +1,51 @@
+import random
+
+from gridiron_gm_pkg.simulation.systems.player.player_weekly_update import advance_player_week
+from gridiron_gm_pkg.simulation.systems.player.player_progression import progress_player
+from gridiron_gm_pkg.simulation.systems.player.player_regression import apply_regression
+from gridiron_gm_pkg.simulation.systems.player.player_dna import (
+    GrowthArc,
+    DEFAULT_REGRESSION_PROFILE,
+)
+
+
+class DummyAttrs:
+    def __init__(self, core):
+        self.core = core
+        self.position_specific = {}
+
+
+class DummyDNA:
+    def __init__(self):
+        self.dev_speed = 1.0
+        self.career_arc = [1.0]
+        self.attribute_caps = {"speed": {"current": 50, "soft_cap": 60, "hard_cap": 90}}
+        self.growth_arc = GrowthArc(23, 27, 30)
+        self.regression_profile = DEFAULT_REGRESSION_PROFILE
+
+
+def make_player(age=25):
+    player = type("P", (), {})()
+    player.attributes = DummyAttrs({"speed": 50})
+    player.dna = DummyDNA()
+    player.hidden_caps = {"speed": 90}
+    player.position = "RB"
+    player.age = age
+    player.get_relevant_attribute_names = lambda: ["speed"]
+    return player
+
+
+def test_advance_player_week_consistency():
+    xp = {"speed": 5.0}
+    rng1 = random.Random(99)
+    p1 = make_player(31)
+    advance_player_week(p1, xp, 1.0, rng1)
+    result1 = p1.attributes.core["speed"]
+
+    rng2 = random.Random(99)
+    p2 = make_player(31)
+    progress_player(p2, xp, 1.0, rng2)
+    apply_regression(p2, p2.age, rng2)
+    result2 = p2.attributes.core["speed"]
+
+    assert result1 == result2


### PR DESCRIPTION
## Summary
- add `player_weekly_update.advance_player_week` helper
- update `Team` with `get_coach_quality` helper
- run weekly player updates in `SeasonManager.handle_week_end`
- test consistency of new weekly update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7d13d2908327a35a7a95db7bff0f