### PR TITLE
Switch regression calculation to weekly

### DIFF
--- a/tests/test_player_dna.py
+++ b/tests/test_player_dna.py
@@ -137,8 +137,18 @@ def test_apply_regression_decreases_values():
     # Force decline to begin at or before the player's current age
     player.dna.growth_arc.decline_start_age = 30
     player_regression.apply_regression(player, age=31)
+    assert player.attributes.core["speed"] <= 80
+    assert player.attributes.core["acceleration"] <= 80
+
+
+def test_regression_accumulates_over_weeks():
+    player = Player("Old", "RB", 31, "1990-01-01", "U", "USA", 22, 70)
+    player.attributes.core["speed"] = 80
+    player.dna.growth_arc.decline_start_age = 30
+    rng = random.Random(42)
+    for _ in range(20):
+        player_regression.apply_regression(player, age=31, rng=rng)
     assert player.attributes.core["speed"] < 80
-    assert player.attributes.core["acceleration"] < 80
 
 
 def _simulate_full_career(player_id: str, position: str, years: int = 15):


### PR DESCRIPTION
## Summary
- calculate weekly regression amounts for players
- add regression buffer to accumulate fractional losses
- expand regression tests for weekly updates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f8b40c52c8327aea946d638b8aba3