### PR TITLE
Fix player DNA generation to use skill priorities

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/player/player_dna.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_dna.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Dict, List, Optional
 
+from gridiron_gm_pkg.simulation.systems.player import attribute_generator
+
 # === Position-based peak age ranges ===
 # These ranges roughly correspond to when players at each position
 # typically reach their athletic prime. They are used to generate
@@ -369,4 +371,18 @@ class PlayerDNA:
     def generate_random_dna(position: str | None = None) -> "PlayerDNA":
         dna = PlayerDNA()
         dna.growth_arc = generate_growth_arc(position)
+        if position:
+            attrs, caps = attribute_generator.generate_attributes_for_position(position)
+            attr_caps: Dict[str, Dict] = {}
+            for attr, val in attrs.items():
+                hard_cap = caps.get(attr, val)
+                soft_cap = min(hard_cap, max(val + random.randint(2, 5), val))
+                attr_caps[attr] = {
+                    "current": val,
+                    "soft_cap": soft_cap,
+                    "hard_cap": hard_cap,
+                    "breakout_history": [],
+                }
+            dna.attribute_caps = attr_caps
+            dna.scouted_caps = dna._generate_scouted_caps()
         return dna

--- a/tests/test_player_growth_summary.py
+++ b/tests/test_player_growth_summary.py
@@ -59,10 +59,15 @@ def test_player_growth_regression_output(tmp_path):
         all_logs.extend(log)
 
     if all_logs:
-        fieldnames = list(all_logs[0].keys())
+        fieldnames = []
+        for row in all_logs:
+            for key in row:
+                if key not in fieldnames:
+                    fieldnames.append(key)
         with open(csv_file, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
-            writer.writerows(all_logs)
+            for row in all_logs:
+                writer.writerow(row)
 
     assert csv_file.exists() and csv_file.stat().st_size > 0


### PR DESCRIPTION
## Summary
- integrate attribute priority system when creating random PlayerDNA
- write CSV logs in tests with all fields present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8ecbdd1c8327baaa5052b825928f