### PR TITLE
Add scramble tendency calculation

### DIFF
--- a/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm_pkg/simulation/entities/player.py
@@ -286,6 +286,7 @@ class Player:
                 "carry_security",
                 "pass_block",
                 "route_running_short",
+                "throw_power",
                 "catching",
             ]
         elif position in ["WR"]:

--- a/gridiron_gm_pkg/simulation/systems/player/player_generation.py
+++ b/gridiron_gm_pkg/simulation/systems/player/player_generation.py
@@ -2,6 +2,39 @@ import random
 from gridiron_gm_pkg.simulation.systems.player.player_dna import PlayerDNA
 
 
+def calculate_scramble_tendency(attributes: dict, archetype: str = "") -> int:
+    """Return a scramble tendency rating based on physical traits.
+
+    Parameters
+    ----------
+    attributes:
+        Mapping of attribute names to starting values. Only ``speed``,
+        ``acceleration`` and ``agility`` are required.
+    archetype:
+        Optional archetype descriptor. Currently unused but retained for
+        future tuning hooks.
+    """
+
+    speed = attributes.get("speed", 60)
+    acceleration = attributes.get("acceleration", 60)
+    agility = attributes.get("agility", 60)
+    awareness = attributes.get("awareness", 60)
+
+    # Weighted score emphasizing raw athleticism
+    scramble_score = speed * 0.5 + acceleration * 0.3 + agility * 0.2
+
+    if scramble_score >= 90:
+        tendency = random.randint(80, 99)
+    elif scramble_score >= 80:
+        tendency = random.randint(65, 85)
+    elif scramble_score >= 70:
+        tendency = random.randint(45, 65)
+    else:
+        tendency = random.randint(20, 45)
+
+    return tendency
+
+
 def generate_player_dna(position: str, level: str = "pro") -> PlayerDNA:
     """Convenience wrapper to produce a ``PlayerDNA`` instance."""
     return PlayerDNA.generate_random_dna(position, level=level)
@@ -30,6 +63,8 @@ def generate_player_attributes_from_caps(dna: PlayerDNA, bias: str = "average") 
 def generate_pro_player(position: str, age: int) -> dict:
     dna = generate_player_dna(position, level="pro")
     attributes = generate_player_attributes_from_caps(dna, bias="pro")
+    if position.upper() == "QB":
+        attributes["scramble_tendency"] = calculate_scramble_tendency(attributes)
     return {
         "position": position,
         "age": age,
@@ -42,6 +77,8 @@ def generate_pro_player(position: str, age: int) -> dict:
 def generate_college_player(position: str, age: int = 21) -> dict:
     dna = generate_player_dna(position, level="college")
     attributes = generate_player_attributes_from_caps(dna, bias="college")
+    if position.upper() == "QB":
+        attributes["scramble_tendency"] = calculate_scramble_tendency(attributes)
     return {
         "position": position,
         "age": age,
@@ -54,6 +91,8 @@ def generate_college_player(position: str, age: int = 21) -> dict:
 def generate_free_agent(position: str, age: int) -> dict:
     dna = generate_player_dna(position, level="pro")
     attributes = generate_player_attributes_from_caps(dna, bias="free_agent")
+    if position.upper() == "QB":
+        attributes["scramble_tendency"] = calculate_scramble_tendency(attributes)
     return {
         "position": position,
         "age": age,

--- a/tests/test_scramble_tendency.py
+++ b/tests/test_scramble_tendency.py
@@ -1,0 +1,28 @@
+import random
+from gridiron_gm_pkg.simulation.systems.player import player_generation
+
+
+def test_calculate_scramble_tendency_ranges():
+    random.seed(0)
+    high = player_generation.calculate_scramble_tendency(
+        {"speed": 95, "acceleration": 90, "agility": 90}
+    )
+    assert 80 <= high <= 99
+
+    random.seed(1)
+    mid_high = player_generation.calculate_scramble_tendency(
+        {"speed": 85, "acceleration": 83, "agility": 80}
+    )
+    assert 65 <= mid_high <= 85
+
+    random.seed(2)
+    mid = player_generation.calculate_scramble_tendency(
+        {"speed": 75, "acceleration": 72, "agility": 70}
+    )
+    assert 45 <= mid <= 65
+
+    random.seed(3)
+    low = player_generation.calculate_scramble_tendency(
+        {"speed": 60, "acceleration": 60, "agility": 60}
+    )
+    assert 20 <= low <= 45


### PR DESCRIPTION
## Summary
- compute scramble tendency from athleticism
- include scramble tendency for generated QB players
- expose QB throw power for RB position attributes
- test scramble tendency values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505660afbc83278acbef32d384f6b9