### PR TITLE
Implement rookie draft class generation

### DIFF
--- a/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm_pkg/simulation/entities/player.py
@@ -201,6 +201,9 @@ class Player:
         self.drafted_by = None
         self.draft_round = None
         self.draft_pick = None
+        self.draft_class_year = None
+        self.is_draft_eligible = False
+        self.rookie = False
 
         self.injuries = []
         self.injury_history = []
@@ -212,16 +215,6 @@ class Player:
         # Track active temporary penalties from injuries
         self.active_injury_effects = {}
 
-    def decrement_contract_year(self) -> None:
-        """Reduce remaining years on contract and flag expiration."""
-        if not self.contract:
-            return
-        years_left = self.contract.get("years_left")
-        if years_left is None:
-            years_left = self.contract.get("years", 0)
-        years_left = max(0, years_left - 1)
-        self.contract["years_left"] = years_left
-        self.contract["expiring"] = years_left == 0
 
         self.traits = {
             "training": [],
@@ -259,6 +252,17 @@ class Player:
         self.mutations = [m.name.lower() for m in self.dna.mutations]
 
         self.generate_caps()
+
+    def decrement_contract_year(self) -> None:
+        """Reduce remaining years on contract and flag expiration."""
+        if not self.contract:
+            return
+        years_left = self.contract.get("years_left")
+        if years_left is None:
+            years_left = self.contract.get("years", 0)
+        years_left = max(0, years_left - 1)
+        self.contract["years_left"] = years_left
+        self.contract["expiring"] = years_left == 0
 
     def init_core_attributes(self):
         """Return baseline attribute mapping common to all players."""
@@ -657,6 +661,9 @@ class Player:
             "drafted_by": self.drafted_by,
             "draft_round": self.draft_round,
             "draft_pick": self.draft_pick,
+            "draft_class_year": self.draft_class_year,
+            "is_draft_eligible": self.is_draft_eligible,
+            "rookie": self.rookie,
             "hidden_caps": self.hidden_caps,
             "scouted_potential": self.scouted_potential,
             "last_attribute_values": self.last_attribute_values,
@@ -705,6 +712,13 @@ class Player:
         player.season_stats = data.get("season_stats", {})
         player.on_injured_reserve = data.get("on_injured_reserve", False)
         player.is_injured = data.get("is_injured", False)
+        player.rookie_year = data.get("rookie_year")
+        player.drafted_by = data.get("drafted_by")
+        player.draft_round = data.get("draft_round")
+        player.draft_pick = data.get("draft_pick")
+        player.draft_class_year = data.get("draft_class_year")
+        player.is_draft_eligible = data.get("is_draft_eligible", False)
+        player.rookie = data.get("rookie", False)
         player.snap_counts = data.get("snap_counts", {})
         player.milestones_hit = set(data.get("milestones_hit", []))
         player.active_injury_effects = data.get("active_injury_effects", [])

--- a/gridiron_gm_pkg/simulation/systems/game/draft_manager.py
+++ b/gridiron_gm_pkg/simulation/systems/game/draft_manager.py
@@ -1,4 +1,6 @@
 from gridiron_gm_pkg.simulation.engine.contract_engine import ContractEngine
+from gridiron_gm_pkg.simulation.utils.college_player_generator import generate_college_player
+import random
 
 class DraftManager:
     """
@@ -8,6 +10,38 @@ class DraftManager:
         self.league = league
         self.transaction_manager = transaction_manager
         self.draft_history = []  # List of dicts: {"round": int, "pick": int, "team": team, "player": player}
+
+    def generate_draft_class(self, num_players: int) -> list:
+        """Generate a rookie draft class."""
+        position_weights = {
+            "QB": 0.05,
+            "RB": 0.09,
+            "WR": 0.17,
+            "TE": 0.07,
+            "OL": 0.14,
+            "DL": 0.15,
+            "LB": 0.1,
+            "CB": 0.13,
+            "S": 0.08,
+            "K": 0.01,
+            "P": 0.01,
+        }
+
+        positions = list(position_weights.keys())
+        weights = list(position_weights.values())
+        draft_year = getattr(self.league, "year", 0) + 1
+        players = []
+
+        for _ in range(num_players):
+            pos = random.choices(positions, weights=weights, k=1)[0]
+            college_year = random.choices([3, 4], weights=[0.3, 0.7])[0]
+            player = generate_college_player(college_year, position=pos)
+            player.is_draft_eligible = True
+            player.draft_class_year = draft_year
+            player.rookie = True
+            players.append(player)
+
+        return players
 
     def determine_draft_order(self):
         """

--- a/gridiron_gm_pkg/simulation/systems/game/offseason_manager.py
+++ b/gridiron_gm_pkg/simulation/systems/game/offseason_manager.py
@@ -97,12 +97,17 @@ class OffseasonManager:
         new_freshmen = generate_freshman_class()
         league.college_db.extend(new_freshmen)
 
-        # 4. Generate this year's draft class using DraftManager for realism
+        # 4. Generate this year's draft class
+        self.create_rookie_draft_class()
+
+    def create_rookie_draft_class(self, num_players: int = 256) -> None:
+        """Generate and store the rookie draft class."""
         from gridiron_gm_pkg.simulation.systems.game.draft_manager import DraftManager
-        draft_manager = DraftManager(league, None)  # TransactionManager will be set later for run_draft
-        year = getattr(self.calendar, "current_year", 1)
-        draft_class = draft_manager.generate_draft_class(year, n_players=256)
-        league.draft_prospects = draft_class
+
+        draft_manager = DraftManager(self.league_manager, None)
+        draft_class = draft_manager.generate_draft_class(num_players)
+        self.league_manager.draft_prospects = draft_class
+        print(f"Draft class created with {len(draft_class)} players")
 
     def _update_active_phases(self):
         """

--- a/gridiron_gm_pkg/simulation/utils/college_player_generator.py
+++ b/gridiron_gm_pkg/simulation/utils/college_player_generator.py
@@ -178,7 +178,7 @@ def project_dev_curve(college_stats, traits=None, scout_accuracy=0.8):
 
     return guess
 
-def generate_college_player(year_in_college: int) -> Player:
+def generate_college_player(year_in_college: int, position: str | None = None) -> Player:
     base_dir = os.path.dirname(os.path.abspath(__file__))
     project_root = os.path.abspath(os.path.join(base_dir, "..", ".."))
     data_dir = os.path.join(project_root, "data")
@@ -189,7 +189,8 @@ def generate_college_player(year_in_college: int) -> Player:
     cities = load_enriched_cities(os.path.join(data_dir, "locations", "enriched_us_cities.json"), DEFAULT_CITIES)
 
     name = f"{random.choice(first_names)} {random.choice(last_names)}"
-    position = random.choice(['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'])
+    if position is None:
+        position = random.choice(['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'])
     dob = datetime.now() - timedelta(days=random.randint(18*365, 23*365))
     age = (datetime.now() - dob).days // 365
 

--- a/gridiron_gm_pkg/tests/test_draft_generation.py
+++ b/gridiron_gm_pkg/tests/test_draft_generation.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from gridiron_gm_pkg.simulation.entities.league import LeagueManager
+from gridiron_gm_pkg.simulation.utils.calendar import Calendar
+from gridiron_gm_pkg.simulation.systems.game.draft_manager import DraftManager
+from gridiron_gm_pkg.simulation.systems.game.offseason_manager import OffseasonManager
+
+
+def test_generate_draft_class_basic():
+    league = LeagueManager()
+    league.calendar = Calendar()
+    dm = DraftManager(league, None)
+    prospects = dm.generate_draft_class(30)
+    assert len(prospects) == 30
+    assert all(getattr(p, "is_draft_eligible") for p in prospects)
+    assert all(getattr(p, "rookie") for p in prospects)
+
+
+def test_offseason_manager_create_rookie_class():
+    league = LeagueManager()
+    league.calendar = Calendar()
+    om = OffseasonManager(league)
+    om.create_rookie_draft_class(num_players=20)
+    assert len(league.draft_prospects) == 20


### PR DESCRIPTION
## Summary
- allow specifying position when generating college players
- generate rookie draft classes via `DraftManager.generate_draft_class`
- create rookie draft classes during offseason refresh
- extend `Player` with draft class metadata
- add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850ae9722148327ad8cc3d9588e14d4