### PR TITLE
Implement CPU free agency logic

### DIFF
--- a/gridiron_gm_pkg/engine/free_agency/__init__.py
+++ b/gridiron_gm_pkg/engine/free_agency/__init__.py
@@ -1,0 +1,3 @@
+"""Free agency utilities and data structures."""
+
+__all__ = ["contract_offer", "free_agent_profile"]

--- a/gridiron_gm_pkg/engine/free_agency/contract_offer.py
+++ b/gridiron_gm_pkg/engine/free_agency/contract_offer.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+@dataclass
+class ContractOffer:
+    """Simple representation of a contract offer."""
+    total_value: float
+    years: int
+    rookie: bool = False
+
+    @property
+    def salary_per_year(self) -> float:
+        # Treat total_value as salary per year for now
+        return self.total_value

--- a/gridiron_gm_pkg/engine/free_agency/free_agent_profile.py
+++ b/gridiron_gm_pkg/engine/free_agency/free_agent_profile.py
@@ -1,0 +1,27 @@
+import random
+from typing import List, Tuple
+from .contract_offer import ContractOffer
+
+class FreeAgentProfile:
+    """Tracks free agent negotiation state."""
+    def __init__(self, player):
+        self.player = player
+        self.days_waiting = 0
+        self.patience_limit = self.determine_patience()
+        self.offers_received: List[Tuple[object, ContractOffer]] = []
+
+    def determine_patience(self) -> int:
+        return random.randint(2, 5)
+
+    def receive_offer(self, team, offer: ContractOffer) -> None:
+        self.offers_received.append((team, offer))
+
+    def daily_tick(self):
+        """Advance one day and decide if an offer is accepted."""
+        self.days_waiting += 1
+        if self.offers_received and self.days_waiting >= self.patience_limit:
+            team, offer = max(self.offers_received, key=lambda x: x[1].salary_per_year)
+            self.offers_received.clear()
+            self.days_waiting = 0
+            return team, offer
+        return None

--- a/gridiron_gm_pkg/simulation/AI/cpu_free_agency.py
+++ b/gridiron_gm_pkg/simulation/AI/cpu_free_agency.py
@@ -1,0 +1,55 @@
+"""Utilities for CPU-controlled free agency behavior."""
+
+import random
+from typing import Dict, List, Tuple
+
+from gridiron_gm_pkg.engine.free_agency.contract_offer import ContractOffer
+
+# Simple positional roster targets based on typical NFL rosters
+POSITION_TARGETS = {
+    "QB": 2,
+    "RB": 3,
+    "WR": 5,
+    "TE": 3,
+    "LT": 2,
+    "LG": 2,
+    "C": 2,
+    "RG": 2,
+    "RT": 2,
+    "DL": 7,
+    "LB": 6,
+    "CB": 5,
+    "S": 3,
+    "K": 1,
+    "P": 1,
+}
+
+
+def evaluate_team_needs(team) -> Dict[str, float]:
+    """Return positional needs with a simple weight."""
+    counts: Dict[str, int] = {}
+    for p in getattr(team, "roster", []):
+        counts[p.position] = counts.get(p.position, 0) + 1
+    needs: Dict[str, float] = {}
+    for pos, target in POSITION_TARGETS.items():
+        have = counts.get(pos, 0)
+        if have < target:
+            needs[pos] = (target - have) + 1
+    return needs
+
+
+def estimate_player_value(player) -> float:
+    """Crude estimation of a player's value."""
+    age_factor = max(0, 30 - getattr(player, "age", 30)) / 30
+    return player.overall + (age_factor * 10)
+
+
+def generate_contract_offer(player, team, value_score) -> Dict:
+    base_salary = max(0.5, round(value_score * 0.1, 2))
+    years = random.randint(1, 3)
+    return {
+        "years": years,
+        "salary_per_year": base_salary,
+        "total_value": base_salary * years,
+        "rookie": False,
+    }

--- a/gridiron_gm_pkg/simulation/entities/player.py
+++ b/gridiron_gm_pkg/simulation/entities/player.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 from dataclasses import dataclass, field
 from typing import List, Dict, Optional
 from gridiron_gm_pkg.simulation.systems.player.player_dna import PlayerDNA
+from gridiron_gm_pkg.engine.free_agency.free_agent_profile import FreeAgentProfile
 
 # Generic attributes shared by all players
 CORE_ATTRIBUTES = [
@@ -252,6 +253,9 @@ class Player:
         self.mutations = [m.name.lower() for m in self.dna.mutations]
 
         self.generate_caps()
+
+        # Profile used when the player is a free agent
+        self.free_agent_profile = FreeAgentProfile(self)
 
     def decrement_contract_year(self) -> None:
         """Reduce remaining years on contract and flag expiration."""
@@ -767,6 +771,7 @@ class Player:
         )
         if not player.hidden_caps or not player.scouted_potential:
             player.generate_caps()
+        player.free_agent_profile = FreeAgentProfile(player)
         return player
 
 

--- a/gridiron_gm_pkg/simulation/systems/transactions/free_agency_manager.py
+++ b/gridiron_gm_pkg/simulation/systems/transactions/free_agency_manager.py
@@ -1,9 +1,18 @@
 import random
+from typing import Dict, List, Tuple
+
+from gridiron_gm_pkg.engine.free_agency.contract_offer import ContractOffer
+from gridiron_gm_pkg.simulation.AI.cpu_free_agency import (
+    evaluate_team_needs,
+    estimate_player_value,
+    generate_contract_offer,
+)
 
 class FreeAgencyManager:
     def __init__(self, game_world):
         self.game_world = game_world
         self.free_agents = game_world.get("free_agents", [])
+        self.pending_offers: Dict[str, List[Tuple[object, Dict]]] = {}
 
     def add_free_agent(self, player):
         if player not in self.free_agents:
@@ -27,7 +36,8 @@ class FreeAgencyManager:
             print(f"{player.name} is no longer a free agent.")
             return False
 
-        if len(team.roster) >= getattr(team, "MAX_ROSTER_SIZE", 53):
+        roster = getattr(team, "roster", getattr(team, "players", []))
+        if len(roster) >= getattr(team, "MAX_ROSTER_SIZE", 53):
             print(f"{team.name} roster is full. Cannot sign {player.name}.")
             return False
 
@@ -44,7 +54,7 @@ class FreeAgencyManager:
             "years_left": contract_offer.years,
             "expiring": False,
         }
-        team.roster.append(player)
+        roster.append(player)
         team.cap_used += contract_offer.salary_per_year
         self.remove_free_agent(player)
 
@@ -63,6 +73,40 @@ class FreeAgencyManager:
             years=years
         )
 
+    # ------------------------------------------------------------------
+    def generate_cpu_offers(self) -> None:
+        """Create contract offers from all CPU-controlled teams."""
+        self.pending_offers.clear()
+        for team in self.game_world["teams"]:
+            if getattr(team, "user_controlled", False):
+                continue
+
+            needs = evaluate_team_needs(team)
+            cap_left = getattr(team, "SALARY_CAP", 200) - getattr(team, "cap_used", 0)
+            offers: List[Tuple[object, Dict]] = []
+
+            roster = getattr(team, "roster", getattr(team, "players", []))
+            for pos, weight in sorted(needs.items(), key=lambda x: x[1], reverse=True):
+                if cap_left <= 0 or len(roster) >= getattr(team, "MAX_ROSTER_SIZE", 53):
+                    break
+                candidates = [p for p in self.free_agents if p.position == pos]
+                if not candidates:
+                    continue
+                player = max(candidates, key=estimate_player_value)
+                value_score = estimate_player_value(player)
+                offer_dict = generate_contract_offer(player, team, value_score * weight)
+                if offer_dict["salary_per_year"] > cap_left:
+                    continue
+                cap_left -= offer_dict["salary_per_year"]
+                offers.append((player, offer_dict))
+                player.free_agent_profile.receive_offer(team, ContractOffer(
+                    total_value=offer_dict["salary_per_year"],
+                    years=offer_dict["years"],
+                ))
+
+            if offers:
+                self.pending_offers[team.id] = offers
+
     def cpu_submit_offers(self):
         for team in self.game_world["teams"]:
             if getattr(team, "user_controlled", False):
@@ -80,20 +124,51 @@ class FreeAgencyManager:
                     agent.free_agent_profile.receive_offer(team, offer)
 
     def advance_free_agency_day(self):
-        # CPU teams submit new offers daily
-        self.cpu_submit_offers()
+        """Process a single day of free agency."""
+        self.generate_cpu_offers()
 
         players_signed_today = []
 
         for player in list(self.free_agents):
-            result = player.free_agent_profile.daily_tick()
+            # gather all offers for this player from pending_offers
+            player_offers = []
+            for team_id, offers in self.pending_offers.items():
+                for p, offer in offers:
+                    if p == player:
+                        team = next((t for t in self.game_world["teams"] if t.id == team_id), None)
+                        if team:
+                            player_offers.append((team, offer))
 
-            if result is not None:
-                team, contract_offer = result
+            # also include any user offers stored on the profile
+            for team, offer_obj in player.free_agent_profile.offers_received:
+                player_offers.append((team, {
+                    "years": offer_obj.years,
+                    "salary_per_year": offer_obj.salary_per_year,
+                    "rookie": offer_obj.rookie,
+                }))
 
-                signed = self.sign_player(team, player, contract_offer)
-                if signed:
-                    players_signed_today.append((player.name, team.name, contract_offer.salary_per_year))
+            if not player_offers:
+                continue
+
+            # choose highest offer with slight randomness
+            player_offers.sort(key=lambda x: x[1]["salary_per_year"], reverse=True)
+            chosen_team, chosen_offer = random.choice(player_offers[:1])
+
+            contract_obj = ContractOffer(
+                total_value=chosen_offer["salary_per_year"],
+                years=chosen_offer["years"],
+                rookie=chosen_offer.get("rookie", False),
+            )
+
+            signed = self.sign_player(chosen_team, player, contract_obj)
+            if signed:
+                players_signed_today.append((player.name, chosen_team.name, contract_obj.salary_per_year))
+
+                # remove signed player from other pending offers
+                for t_id in list(self.pending_offers.keys()):
+                    self.pending_offers[t_id] = [
+                        (p, o) for (p, o) in self.pending_offers[t_id] if p != player
+                    ]
 
         if players_signed_today:
             print("\n[Free Agency Signings Today]")


### PR DESCRIPTION
## Summary
- add contract and free-agent profile helpers
- implement CPU free agency evaluation helpers
- extend Player with FreeAgentProfile
- add generate_cpu_offers and enhanced signing logic

## Testing
- `pip install numpy matplotlib seaborn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d13013408327a03a1e43e5e84fa6