### PR TITLE
Add DraftBoardManager for team draft boards

### DIFF
--- a/gridiron_gm_pkg/simulation/systems/game/draft_board_manager.py
+++ b/gridiron_gm_pkg/simulation/systems/game/draft_board_manager.py
@@ -1,0 +1,73 @@
+"""Utilities for generating team-specific draft boards."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+from gridiron_gm_pkg.simulation.entities.scout import Scout
+from gridiron_gm_pkg.simulation.entities.player import Player
+from gridiron_gm_pkg.simulation.entities.team import Team
+from gridiron_gm_pkg.simulation.entities.league import LeagueManager
+
+
+def evaluate_team_need(team: Team, position: str) -> int:
+    """Return a rough score for how badly a team needs a position."""
+    position_players = [p for p in team.players if p.position == position]
+    if not position_players:
+        return 10
+    if all(p.overall < 72 for p in position_players):
+        return 7
+    if all(p.overall < 78 for p in position_players):
+        return 4
+    return 0
+
+
+class DraftBoardManager:
+    """Generate draft boards ranking prospects for each team."""
+
+    def __init__(self, league: LeagueManager) -> None:
+        self.league = league
+        self.draft_boards: Dict[str, List[Dict[str, Any]]] = {}
+
+    # ------------------------------------------------------------------
+    def _get_team_scout(self, team: Team) -> Scout:
+        """Return the scout assigned to the team or a generic one."""
+        scout = team.staff.get("scout") if hasattr(team, "staff") else None
+        if not isinstance(scout, Scout):
+            scout = Scout(
+                name=f"{team.abbreviation} Scout",
+                evaluation_skill=getattr(team, "scouting_accuracy", 0.6),
+            )
+        return scout
+
+    # ------------------------------------------------------------------
+    def generate_team_board(
+        self, team: Team, prospects: List[Player], top_n: int = 150
+    ) -> List[Dict[str, Any]]:
+        """Generate and store a draft board for a single team."""
+        scout = self._get_team_scout(team)
+        board: List[Dict[str, Any]] = []
+
+        for player in prospects:
+            report = scout.evaluate_player(player)
+            ovr_est = sum(report.get("ovr_range", [50, 50])) / 2
+            pot_est = sum(report.get("pot_range", [50, 50])) / 2
+            need_bonus = evaluate_team_need(team, player.position)
+            score = ovr_est * 0.6 + pot_est * 0.4 + need_bonus
+            board.append({"player": player, "score": round(score, 2), "report": report})
+
+        board.sort(key=lambda x: x["score"], reverse=True)
+        team.draft_board = board[:top_n]
+        self.draft_boards[team.id] = team.draft_board
+        return team.draft_board
+
+    # ------------------------------------------------------------------
+    def generate_all_boards(
+        self, draft_prospects: List[Player] | None = None, teams: List[Team] | None = None
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Generate draft boards for all teams in the league."""
+        prospects = draft_prospects or list(self.league.draft_prospects)
+        targets = teams or list(self.league.teams)
+        for team in targets:
+            self.generate_team_board(team, prospects)
+        return self.draft_boards

--- a/gridiron_gm_pkg/tests/test_draft_board.py
+++ b/gridiron_gm_pkg/tests/test_draft_board.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from gridiron_gm_pkg.simulation.entities.league import LeagueManager
+from gridiron_gm_pkg.simulation.entities.team import Team
+from gridiron_gm_pkg.simulation.entities.scout import Scout
+from gridiron_gm_pkg.simulation.entities.player import Player
+from gridiron_gm_pkg.simulation.systems.game.draft_board_manager import DraftBoardManager
+from gridiron_gm_pkg.simulation.utils.calendar import Calendar
+
+
+def test_generate_draft_boards_basic():
+    league = LeagueManager()
+    league.calendar = Calendar()
+    team1 = Team("Alpha", "A", "A")
+    team2 = Team("Beta", "B", "B")
+    team1.staff["scout"] = Scout("Alpha Scout", evaluation_skill=0.7)
+    team2.staff["scout"] = Scout("Beta Scout", evaluation_skill=0.7)
+    league.add_team(team1)
+    league.add_team(team2)
+
+    prospects = []
+    for i in range(20):
+        p = Player(
+            name=f"Prospect {i}",
+            position="QB" if i % 3 == 0 else "WR",
+            age=21,
+            dob="2004-01-01",
+            college="Test",
+            birth_location="Testville",
+            jersey_number=i + 1,
+            overall=70,
+        )
+        p.potential = 85
+        prospects.append(p)
+    league.draft_prospects = prospects
+
+    board_manager = DraftBoardManager(league)
+    boards = board_manager.generate_all_boards()
+
+    assert team1.id in boards
+    assert team2.id in boards
+    assert len(boards[team1.id]) <= 20
+    assert len(boards[team2.id]) <= 20
+    assert boards[team1.id][0]["score"] >= boards[team1.id][-1]["score"]


### PR DESCRIPTION
## Summary
- implement `DraftBoardManager` to produce per‑team draft boards using scout evaluation and team needs
- include simple team need evaluator within the manager
- add unit test for draft board generation

## Testing
- `pip install -r requirements.txt`
- `pytest -q gridiron_gm_pkg/tests/test_draft_generation.py gridiron_gm_pkg/tests/test_draft_board.py`

------
https://chatgpt.com/codex/tasks/task_e_6850d6be9b208327b906e38ac51dd7bb