### PR TITLE
Add scouting fog-of-war helpers

### DIFF
--- a/gridiron_gm_pkg/players/player.py
+++ b/gridiron_gm_pkg/players/player.py
@@ -1,0 +1,22 @@
+"""Helpers for presenting player data with scouting fog-of-war."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from gridiron_gm_pkg.simulation.entities.player import Player
+from gridiron_gm_pkg.simulation.entities.scout import Scout
+from gridiron_gm_pkg.simulation.entities.team import Team
+from gridiron_gm_pkg.simulation.systems.scouting.scout_engine import ScoutEngine
+
+_engine = ScoutEngine()
+
+
+def get_rookie_view(player: Player, scout: Optional[Scout] = None, team: Optional[Team] = None) -> Dict[str, int]:
+    """Return masked OVR and POT for display based on scouting info."""
+    accuracy = getattr(team, "scouting_accuracy", 0.6)
+    bias = getattr(team, "scouting_bias", 0.0)
+    if scout is not None:
+        accuracy = (accuracy + getattr(scout, "evaluation_skill", 0.5)) / 2
+        bias += getattr(scout, "bias_profile", {}).get("overall", 0.0)
+    return _engine.mask_player_ratings(player, accuracy, bias)

--- a/gridiron_gm_pkg/simulation/systems/scouting/scout_engine.py
+++ b/gridiron_gm_pkg/simulation/systems/scouting/scout_engine.py
@@ -1,0 +1,34 @@
+import random
+from typing import Dict
+
+from gridiron_gm_pkg.simulation.entities.player import Player
+
+class ScoutEngine:
+    """Utility class for masking ratings based on scouting accuracy and bias."""
+
+    def __init__(self, rng: random.Random | None = None) -> None:
+        self.rng = rng or random.Random()
+
+    def apply_rating_mask(self, rating: float, accuracy: float, bias: float = 0.0) -> int:
+        """Return a masked rating value.
+
+        Parameters
+        ----------
+        rating : float
+            True rating value.
+        accuracy : float
+            Scouting accuracy in range 0-1.
+        bias : float
+            Team-specific bias modifier (positive = optimistic).
+        """
+        biased = rating + bias * 10.0
+        noise = self.rng.gauss(0.0, max(0.0, 1.0 - accuracy) * 5.0)
+        masked = biased + noise
+        return int(max(40, min(99, round(masked))))
+
+    def mask_player_ratings(self, player: Player, accuracy: float, bias: float = 0.0) -> Dict[str, int]:
+        """Return masked overall and potential ratings for a player."""
+        overall = self.apply_rating_mask(player.overall, accuracy, bias)
+        true_pot = player.potential if player.potential is not None else player.hidden_caps.get("overall", player.overall)
+        potential = self.apply_rating_mask(true_pot, accuracy, bias)
+        return {"overall": overall, "potential": potential}


### PR DESCRIPTION
## Summary
- add `ScoutEngine` for masking ratings based on accuracy/bias
- expose `get_rookie_view` helper under `players/`

## Testing
- `pip install numpy seaborn matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850eb03995883279c02035b9329e742