### PR TITLE
Add Unity frontend scaffold

### DIFF
--- a/UnityFrontend/Assets/Scripts/LeagueState.cs
+++ b/UnityFrontend/Assets/Scripts/LeagueState.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class TeamInfo
+{
+    public string name;
+    public string abbreviation;
+}
+
+[Serializable]
+public class GameResult
+{
+    public string home;
+    public string away;
+    public int home_score;
+    public int away_score;
+    public int home_yards;
+    public int away_yards;
+}
+
+[Serializable]
+public class LeagueState
+{
+    public int week;
+    public Dictionary<string, List<GameResult>> results_by_week;
+    public List<TeamInfo> teams;
+}

--- a/UnityFrontend/Assets/Scripts/MainMenuController.cs
+++ b/UnityFrontend/Assets/Scripts/MainMenuController.cs
@@ -1,0 +1,135 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Newtonsoft.Json;
+
+public class MainMenuController : MonoBehaviour
+{
+    [Header("GM Settings")]
+    public Dropdown gmDropdown;
+    public InputField gmNameInput;
+    public Button createGmButton;
+
+    [Header("League Settings")]
+    public Dropdown teamDropdown;
+    public Text weekText;
+    public Text resultsText;
+    public Button simulateButton;
+
+    private LeagueState leagueState;
+    private string leagueStatePath;
+
+    void Start()
+    {
+        leagueStatePath = Path.Combine(Application.dataPath, "..", "league_state.json");
+        LoadLeagueState();
+        PopulateTeamDropdown();
+        PopulateGmDropdown();
+        UpdateUI();
+
+        if (createGmButton != null)
+            createGmButton.onClick.AddListener(CreateGm);
+        if (simulateButton != null)
+            simulateButton.onClick.AddListener(SimulateWeek);
+    }
+
+    void LoadLeagueState()
+    {
+        if (!File.Exists(leagueStatePath))
+        {
+            UnityEngine.Debug.LogError("league_state.json not found at " + leagueStatePath);
+            return;
+        }
+        string json = File.ReadAllText(leagueStatePath);
+        leagueState = JsonConvert.DeserializeObject<LeagueState>(json);
+    }
+
+    void PopulateTeamDropdown()
+    {
+        if (teamDropdown == null || leagueState == null) return;
+        teamDropdown.ClearOptions();
+        var options = new List<string>();
+        foreach (var team in leagueState.teams)
+        {
+            options.Add($"{team.abbreviation} - {team.name}");
+        }
+        teamDropdown.AddOptions(options);
+    }
+
+    void PopulateGmDropdown()
+    {
+        if (gmDropdown == null) return;
+        gmDropdown.ClearOptions();
+        var gmDir = Path.Combine(Application.dataPath, "..", "gms");
+        var options = new List<string>();
+        if (Directory.Exists(gmDir))
+        {
+            foreach (var f in Directory.GetFiles(gmDir, "*.json"))
+            {
+                options.Add(Path.GetFileNameWithoutExtension(f));
+            }
+        }
+        gmDropdown.AddOptions(options);
+    }
+
+    void UpdateUI()
+    {
+        if (leagueState == null) return;
+        if (weekText != null)
+            weekText.text = "Week " + leagueState.week;
+        if (resultsText != null)
+        {
+            if (leagueState.results_by_week != null && leagueState.results_by_week.TryGetValue(leagueState.week.ToString(), out var results))
+            {
+                var lines = new List<string>();
+                foreach (var res in results)
+                {
+                    lines.Add($"{res.away} {res.away_score} @ {res.home} {res.home_score}");
+                }
+                resultsText.text = string.Join("\n", lines);
+            }
+            else
+            {
+                resultsText.text = "No results yet.";
+            }
+        }
+    }
+
+    void CreateGm()
+    {
+        if (gmNameInput == null) return;
+        var name = gmNameInput.text.Trim();
+        if (string.IsNullOrEmpty(name)) return;
+
+        var gmDir = Path.Combine(Application.dataPath, "..", "gms");
+        Directory.CreateDirectory(gmDir);
+        var path = Path.Combine(gmDir, name + ".json");
+        if (!File.Exists(path))
+            File.WriteAllText(path, "{}");
+
+        PopulateGmDropdown();
+        int index = gmDropdown.options.FindIndex(o => o.text == name);
+        if (index >= 0)
+            gmDropdown.value = index;
+    }
+
+    void SimulateWeek()
+    {
+        var process = new Process();
+        process.StartInfo.FileName = "python";
+        process.StartInfo.Arguments = "scripts/run_weekly_simulation.py";
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.Start();
+        process.WaitForExit();
+
+        UnityEngine.Debug.Log(process.StandardOutput.ReadToEnd());
+        UnityEngine.Debug.LogError(process.StandardError.ReadToEnd());
+
+        LoadLeagueState();
+        UpdateUI();
+    }
+}

--- a/UnityFrontend/README.md
+++ b/UnityFrontend/README.md
@@ -1,0 +1,20 @@
+# Unity Frontend
+
+This folder contains a simple Unity UI scaffold for Gridiron GM.
+
+## Features
+
+- Loads `league_state.json` from the project root.
+- Displays the current week number and recent game results.
+- Allows the user to create or select a GM profile.
+- Lets the player choose a team from a dropdown list.
+- A `Simulate Week` button executes `python scripts/run_weekly_simulation.py` and refreshes the data.
+
+## Usage
+
+1. Open this folder as a Unity project or copy the `Assets` directory into your existing project.
+2. Ensure that `league_state.json` exists at the root of the repository.
+3. Create a Canvas, add the necessary UI elements, and attach `MainMenuController`.
+4. Hook up the dropdowns, text fields and buttons in the inspector.
+
+This setup is intentionally lightweight and is meant to get the frontend running quickly.


### PR DESCRIPTION
## Summary
- add UnityFrontend folder with basic UI scripts
- show how to load league state and run weekly simulation
- document usage instructions for Unity client

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f262891883278b897ffbdfe0b385