### PR TITLE
Add scroll list for weekly results

### DIFF
--- a/UnityFrontend/Assets/Scripts/GameResultRow.cs
+++ b/UnityFrontend/Assets/Scripts/GameResultRow.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using TMPro;
+
+public class GameResultRow : MonoBehaviour
+{
+    public TMP_Text homeTeamText;
+    public TMP_Text awayTeamText;
+    public TMP_Text homeScoreText;
+    public TMP_Text awayScoreText;
+
+    public void SetData(GameResult result)
+    {
+        if (result == null) return;
+        if (homeTeamText != null) homeTeamText.text = result.home;
+        if (awayTeamText != null) awayTeamText.text = result.away;
+        if (homeScoreText != null) homeScoreText.text = result.home_score.ToString();
+        if (awayScoreText != null) awayScoreText.text = result.away_score.ToString();
+    }
+}

--- a/UnityFrontend/Assets/Scripts/MainMenuController.cs
+++ b/UnityFrontend/Assets/Scripts/MainMenuController.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -18,6 +19,10 @@ public class MainMenuController : MonoBehaviour
     public Text resultsText;
     public Button simulateButton;
 
+    [Header("Results UI")]
+    public GameObject gameResultRowPrefab;
+    public Transform resultsContent;
+
     private LeagueState leagueState;
     private string leagueStatePath;
 
@@ -28,6 +33,7 @@ public class MainMenuController : MonoBehaviour
         PopulateTeamDropdown();
         PopulateGmDropdown();
         UpdateUI();
+        PopulateGameResults();
 
         if (createGmButton != null)
             createGmButton.onClick.AddListener(CreateGm);
@@ -97,6 +103,42 @@ public class MainMenuController : MonoBehaviour
         }
     }
 
+    void PopulateGameResults()
+    {
+        if (resultsContent == null || gameResultRowPrefab == null || leagueState == null)
+            return;
+
+        foreach (Transform child in resultsContent)
+        {
+            Destroy(child.gameObject);
+        }
+
+        if (leagueState.results_by_week != null &&
+            leagueState.results_by_week.TryGetValue(leagueState.week.ToString(), out var games))
+        {
+            foreach (var game in games)
+            {
+                var rowObj = Instantiate(gameResultRowPrefab, resultsContent);
+                var row = rowObj.GetComponent<GameResultRow>();
+                if (row != null)
+                {
+                    row.SetData(game);
+                }
+                else
+                {
+                    var texts = rowObj.GetComponentsInChildren<TMP_Text>();
+                    if (texts.Length >= 4)
+                    {
+                        texts[0].text = game.home;
+                        texts[1].text = game.away;
+                        texts[2].text = game.home_score.ToString();
+                        texts[3].text = game.away_score.ToString();
+                    }
+                }
+            }
+        }
+    }
+
     void CreateGm()
     {
         if (gmNameInput == null) return;
@@ -131,5 +173,6 @@ public class MainMenuController : MonoBehaviour
 
         LoadLeagueState();
         UpdateUI();
+        PopulateGameResults();
     }
 }


### PR DESCRIPTION
## Summary
- show weekly game results in a scroll view
- expose prefab and content references
- add GameResultRow component for row prefabs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f5e3ea348327ad509afa623518e0