### PR TITLE
Load league state from save folder

### DIFF
--- a/UnityFrontend/Assets/Scripts/MainMenuController.cs
+++ b/UnityFrontend/Assets/Scripts/MainMenuController.cs
@@ -3,7 +3,7 @@ using UnityEngine.UI;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using Newtonsoft.Json;
+using System;
 
 public class MainMenuController : MonoBehaviour
 {
@@ -23,11 +23,19 @@ public class MainMenuController : MonoBehaviour
 
     void Start()
     {
-        leagueStatePath = Path.Combine(Application.dataPath, "..", "league_state.json");
+        leagueStatePath = Path.Combine(Application.dataPath, "..", "save", "league_state.json");
         LoadLeagueState();
         PopulateTeamDropdown();
         PopulateGmDropdown();
-        UpdateUI();
+        if (leagueState != null)
+            UpdateUI();
+        else
+        {
+            if (weekText != null)
+                weekText.text = "Week N/A";
+            if (resultsText != null)
+                resultsText.text = "No league data.";
+        }
 
         if (createGmButton != null)
             createGmButton.onClick.AddListener(CreateGm);
@@ -43,7 +51,17 @@ public class MainMenuController : MonoBehaviour
             return;
         }
         string json = File.ReadAllText(leagueStatePath);
-        leagueState = JsonConvert.DeserializeObject<LeagueState>(json);
+        leagueState = JsonUtility.FromJson<LeagueState>(json);
+
+        UnityEngine.Debug.Log("Current Week: " + leagueState.week);
+        if (leagueState.results_by_week != null && leagueState.results_by_week.TryGetValue("1", out var week1))
+        {
+            for (int i = 0; i < Math.Min(3, week1.Count); i++)
+            {
+                var res = week1[i];
+                UnityEngine.Debug.Log($"{res.away} {res.away_score} @ {res.home} {res.home_score}");
+            }
+        }
     }
 
     void PopulateTeamDropdown()


### PR DESCRIPTION
## Summary
- update path to load `save/league_state.json`
- use `File.ReadAllText` and `JsonUtility.FromJson` for deserialization
- log the first three results from week 1 on startup
- show placeholder UI when no save file is found

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy/seaborn/matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_6850f52cb4648327a97a942c8796738a