### PR TITLE
Add roster viewer to Unity frontend

### DIFF
--- a/UnityFrontend/Assets/Scripts/LeagueState.cs
+++ b/UnityFrontend/Assets/Scripts/LeagueState.cs
@@ -2,10 +2,27 @@ using System;
 using System.Collections.Generic;
 
 [Serializable]
+public class ContractInfo
+{
+    public int years_left;
+}
+
+[Serializable]
+public class PlayerInfo
+{
+    public string name;
+    public string position;
+    public int age;
+    public int overall;
+    public ContractInfo contract;
+}
+
+[Serializable]
 public class TeamInfo
 {
     public string name;
     public string abbreviation;
+    public List<PlayerInfo> roster;
 }
 
 [Serializable]

--- a/UnityFrontend/Assets/Scripts/MainMenuController.cs
+++ b/UnityFrontend/Assets/Scripts/MainMenuController.cs
@@ -24,6 +24,10 @@ public class MainMenuController : MonoBehaviour
     public GameObject gameResultRowPrefab;
     public Transform resultsContent;
 
+    [Header("Roster UI")]
+    public GameObject playerRowPrefab;
+    public Transform rosterContent;
+
     private LeagueState leagueState;
     private string leagueStatePath;
 
@@ -33,8 +37,13 @@ public class MainMenuController : MonoBehaviour
         LoadLeagueState();
         PopulateTeamDropdown();
         PopulateGmDropdown();
+        if (teamDropdown != null)
+            teamDropdown.onValueChanged.AddListener(delegate { OnTeamSelected(); });
         if (leagueState != null)
+        {
             UpdateUI();
+            OnTeamSelected();
+        }
         else
         {
             if (weekText != null)
@@ -157,6 +166,36 @@ public class MainMenuController : MonoBehaviour
         }
     }
 
+    void OnTeamSelected()
+    {
+        if (teamDropdown == null || leagueState == null) return;
+        if (teamDropdown.value < 0 || teamDropdown.value >= leagueState.teams.Count) return;
+        var team = leagueState.teams[teamDropdown.value];
+        PopulateTeamRoster(team);
+    }
+
+    void PopulateTeamRoster(TeamInfo selectedTeam)
+    {
+        if (selectedTeam == null || rosterContent == null || playerRowPrefab == null)
+            return;
+
+        foreach (Transform child in rosterContent)
+        {
+            Destroy(child.gameObject);
+        }
+
+        if (selectedTeam.roster != null)
+        {
+            foreach (var player in selectedTeam.roster)
+            {
+                var rowObj = Instantiate(playerRowPrefab, rosterContent);
+                var row = rowObj.GetComponent<PlayerRow>();
+                if (row != null)
+                    row.SetData(player);
+            }
+        }
+    }
+
     void CreateGm()
     {
         if (gmNameInput == null) return;
@@ -212,6 +251,7 @@ public class MainMenuController : MonoBehaviour
         LoadLeagueState();
         UpdateUI();
         PopulateGameResults();
+        OnTeamSelected();
     }
 }
 

--- a/UnityFrontend/Assets/Scripts/PlayerRow.cs
+++ b/UnityFrontend/Assets/Scripts/PlayerRow.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using TMPro;
+
+public class PlayerRow : MonoBehaviour
+{
+    public TMP_Text nameText;
+    public TMP_Text positionText;
+    public TMP_Text ageText;
+    public TMP_Text overallText;
+    public TMP_Text contractText;
+
+    public void SetData(PlayerInfo info)
+    {
+        if (info == null) return;
+        if (nameText != null) nameText.text = info.name;
+        if (positionText != null) positionText.text = info.position;
+        if (ageText != null) ageText.text = info.age.ToString();
+        if (overallText != null) overallText.text = info.overall.ToString();
+        if (contractText != null)
+        {
+            int years = info.contract != null ? info.contract.years_left : 0;
+            contractText.text = years.ToString();
+        }
+    }
+}

--- a/UnityFrontend/README.md
+++ b/UnityFrontend/README.md
@@ -8,6 +8,7 @@ This folder contains a simple Unity UI scaffold for Gridiron GM.
 - Displays the current week number and recent game results.
 - Allows the user to create or select a GM profile.
 - Lets the player choose a team from a dropdown list.
+- Selecting a team now shows a scrollable roster with key player info.
 - A `Simulate Week` button executes `python scripts/run_weekly_simulation.py` and refreshes the data.
 
 ## Usage
@@ -16,5 +17,6 @@ This folder contains a simple Unity UI scaffold for Gridiron GM.
 2. Ensure that `league_state.json` exists at the root of the repository.
 3. Create a Canvas, add the necessary UI elements, and attach `MainMenuController`.
 4. Hook up the dropdowns, text fields and buttons in the inspector.
+5. Add a ScrollView for the roster display and assign the `PlayerRow` prefab to `MainMenuController`.
 
 This setup is intentionally lightweight and is meant to get the frontend running quickly.

--- a/scripts/run_weekly_simulation.py
+++ b/scripts/run_weekly_simulation.py
@@ -56,6 +56,22 @@ def update_league_state(teams: List[Team], week: int, results_by_week: Dict[int,
             {
                 "name": getattr(team, "team_name", getattr(team, "name", "")),
                 "abbreviation": team.abbreviation,
+                "roster": [
+                    {
+                        "name": p.name,
+                        "position": p.position,
+                        "age": getattr(p, "age", 0),
+                        "overall": getattr(p, "overall", 0),
+                        "contract": {
+                            "years_left": (
+                                p.contract.get("years_left", p.contract.get("years", 0))
+                                if getattr(p, "contract", None)
+                                else 0
+                            )
+                        },
+                    }
+                    for p in getattr(team, "players", [])
+                ],
             }
             for team in teams
         ],


### PR DESCRIPTION
## Summary
- expand LeagueState classes to include roster info
- add PlayerRow component for roster entries
- update MainMenuController to populate roster scroll view
- include player rosters in `run_weekly_simulation.py`
- document roster viewer in UnityFrontend README

## Testing
- `pip install numpy matplotlib seaborn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f7e4ae348327a82fbb3bce1286a8