### PR TITLE
Add contract bridge and cap view infrastructure

### DIFF
--- a/UnityFrontend/Assets/Editor/PrefabTools.cs
+++ b/UnityFrontend/Assets/Editor/PrefabTools.cs
@@ -1,0 +1,37 @@
+#if UNITY_EDITOR
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using Gridiron.Core;
+
+public static class PrefabTools
+{
+    [MenuItem("GG/Tools/Clear Season Save")]
+    public static void ClearSeasonSave()
+    {
+        var path = GGPaths.Save(GGConventions.SeasonSaveFile);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+            Debug.Log("Season save cleared");
+        }
+    }
+
+    [MenuItem("GG/Tools/Scan Missing Scripts")]
+    public static void ScanMissingScripts()
+    {
+        var objects = Resources.FindObjectsOfTypeAll<GameObject>();
+        foreach (var go in objects)
+        {
+            var comps = go.GetComponents<Component>();
+            foreach (var c in comps)
+            {
+                if (c == null)
+                {
+                    Debug.LogWarning("Missing script on " + go.name);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/UnityFrontend/Assets/Scripts/Bridge/Dto/Contracts.cs
+++ b/UnityFrontend/Assets/Scripts/Bridge/Dto/Contracts.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using Gridiron.Core;
+
+namespace Gridiron.Bridge.Dto
+{
+    [Serializable]
+    public class ContractYearTerm
+    {
+        public int Year;
+        public long Base;
+        public long SigningProrated;
+        public long RosterBonus;
+        public long WorkoutBonus;
+        public long GuaranteedBase;
+    }
+
+    [Serializable]
+    public class Guarantee
+    {
+        public string Type;
+        public int ThroughYear;
+    }
+
+    [Serializable]
+    public class Incentive
+    {
+        public string Type;
+        public long Amount;
+        public string Metric;
+        public string Threshold;
+    }
+
+    [Serializable]
+    public class ContractDTO
+    {
+        public string ApiVersion;
+        public int StartYear;
+        public int EndYear;
+        public List<ContractYearTerm> Terms;
+        public List<Guarantee> Guarantees;
+        public List<Incentive> Incentives;
+        public Dictionary<string, bool> Flags;
+        public List<string> Notes;
+        public Dictionary<string, object> Extra = new Dictionary<string, object>();
+
+        public static ContractDTO FromJson(string json)
+        {
+            var dict = MiniJson.Deserialize(json) as Dictionary<string, object>;
+            var dto = new ContractDTO();
+            if (dict == null) return dto;
+
+            dto.ApiVersion = GetString(dict, "apiVersion");
+            dto.StartYear = GetInt(dict, "startYear");
+            dto.EndYear = GetInt(dict, "endYear");
+            dto.Terms = ParseTerms(dict);
+            dto.Guarantees = ParseGuarantees(dict);
+            dto.Incentives = ParseIncentives(dict);
+            dto.Flags = ParseFlags(dict);
+            dto.Notes = ParseNotes(dict);
+
+            var known = new HashSet<string> { "apiVersion", "startYear", "endYear", "terms", "guarantees", "incentives", "flags", "notes" };
+            foreach (var kv in dict)
+            {
+                if (!known.Contains(kv.Key))
+                {
+                    dto.Extra[kv.Key] = kv.Value;
+                }
+            }
+            return dto;
+        }
+
+        private static List<ContractYearTerm> ParseTerms(Dictionary<string, object> dict)
+        {
+            var list = new List<ContractYearTerm>();
+            if (dict.TryGetValue("terms", out var obj) && obj is List<object> arr)
+            {
+                foreach (var item in arr)
+                {
+                    var d = item as Dictionary<string, object>;
+                    if (d == null) continue;
+                    var term = new ContractYearTerm
+                    {
+                        Year = GetInt(d, "year"),
+                        Base = GetLong(d, "base"),
+                        SigningProrated = GetLong(d, "signingProrated"),
+                        RosterBonus = GetLong(d, "rosterBonus"),
+                        WorkoutBonus = GetLong(d, "workoutBonus"),
+                        GuaranteedBase = GetLong(d, "guaranteedBase")
+                    };
+                    list.Add(term);
+                }
+            }
+            return list;
+        }
+
+        private static List<Guarantee> ParseGuarantees(Dictionary<string, object> dict)
+        {
+            var list = new List<Guarantee>();
+            if (dict.TryGetValue("guarantees", out var obj) && obj is List<object> arr)
+            {
+                foreach (var item in arr)
+                {
+                    var d = item as Dictionary<string, object>;
+                    if (d == null) continue;
+                    list.Add(new Guarantee
+                    {
+                        Type = GetString(d, "type"),
+                        ThroughYear = GetInt(d, "throughYear")
+                    });
+                }
+            }
+            return list;
+        }
+
+        private static List<Incentive> ParseIncentives(Dictionary<string, object> dict)
+        {
+            var list = new List<Incentive>();
+            if (dict.TryGetValue("incentives", out var obj) && obj is List<object> arr)
+            {
+                foreach (var item in arr)
+                {
+                    var d = item as Dictionary<string, object>;
+                    if (d == null) continue;
+                    list.Add(new Incentive
+                    {
+                        Type = GetString(d, "type"),
+                        Amount = GetLong(d, "amount"),
+                        Metric = GetString(d, "metric"),
+                        Threshold = GetString(d, "threshold")
+                    });
+                }
+            }
+            return list;
+        }
+
+        private static Dictionary<string, bool> ParseFlags(Dictionary<string, object> dict)
+        {
+            var result = new Dictionary<string, bool>();
+            if (dict.TryGetValue("flags", out var obj) && obj is Dictionary<string, object> d)
+            {
+                foreach (var kv in d)
+                {
+                    result[kv.Key] = Convert.ToBoolean(kv.Value);
+                }
+            }
+            return result;
+        }
+
+        private static List<string> ParseNotes(Dictionary<string, object> dict)
+        {
+            var list = new List<string>();
+            if (dict.TryGetValue("notes", out var obj) && obj is List<object> arr)
+            {
+                foreach (var item in arr)
+                {
+                    if (item is string s)
+                    {
+                        list.Add(s);
+                    }
+                }
+            }
+            return list;
+        }
+
+        private static string GetString(Dictionary<string, object> dict, string key)
+        {
+            if (dict.TryGetValue(key, out var obj)) return obj as string;
+            return null;
+        }
+
+        private static int GetInt(Dictionary<string, object> dict, string key)
+        {
+            if (dict.TryGetValue(key, out var obj))
+            {
+                return Convert.ToInt32(obj);
+            }
+            return 0;
+        }
+
+        private static long GetLong(Dictionary<string, object> dict, string key)
+        {
+            if (dict.TryGetValue(key, out var obj))
+            {
+                return Convert.ToInt64(obj);
+            }
+            return 0L;
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Bridge/Validation/ContractValidator.cs
+++ b/UnityFrontend/Assets/Scripts/Bridge/Validation/ContractValidator.cs
@@ -1,0 +1,49 @@
+using System;
+using Gridiron.Bridge.Dto;
+
+namespace Gridiron.Bridge.Validation
+{
+    public class GGDataException : Exception
+    {
+        public string Code { get; }
+
+        public GGDataException(string code, string message) : base(message)
+        {
+            Code = code;
+        }
+    }
+
+    public static class ContractValidator
+    {
+        public static void Validate(ContractDTO c)
+        {
+            if (c == null)
+            {
+                throw new GGDataException("GG2001", "Null contract payload");
+            }
+
+            if (c.ApiVersion != "gg.v1")
+            {
+                throw new GGDataException("GG2002", "Version " + c.ApiVersion + " not supported");
+            }
+
+            if (c.Terms == null || c.Terms.Count == 0)
+            {
+                throw new GGDataException("GG2003", "Missing terms[]");
+            }
+
+            foreach (var term in c.Terms)
+            {
+                if (term.Year < 2000 || term.Year > 2100)
+                {
+                    throw new GGDataException("GG2003", "Term year out of range");
+                }
+
+                if (term.Base < 0 || term.SigningProrated < 0 || term.RosterBonus < 0 || term.WorkoutBonus < 0 || term.GuaranteedBase < 0)
+                {
+                    throw new GGDataException("GG2003", "Negative amounts");
+                }
+            }
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Bridge/Validation/DataIO.cs
+++ b/UnityFrontend/Assets/Scripts/Bridge/Validation/DataIO.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using UnityEngine;
+using Gridiron.Core;
+using Gridiron.Bridge.Dto;
+
+namespace Gridiron.Bridge.Validation
+{
+    public static class DataIO
+    {
+        public static T LoadJson<T>(string relativePath)
+        {
+            var fullPath = GGPaths.Project(relativePath.TrimStart('/'));
+            GGLog.Info("Loading " + fullPath);
+            var json = File.ReadAllText(fullPath);
+            if (typeof(T) == typeof(ContractDTO))
+            {
+                object dto = ContractDTO.FromJson(json);
+                return (T)dto;
+            }
+            return JsonUtility.FromJson<T>(json);
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Core/GGConventions.cs
+++ b/UnityFrontend/Assets/Scripts/Core/GGConventions.cs
@@ -1,0 +1,9 @@
+namespace Gridiron.Core
+{
+    public static class GGConventions
+    {
+        public const string SelectedTeamKey = "gg_selected_team";
+        public const string SeasonSaveFile = "season_save.json";
+        public const string TeamsJsonFile = "teams.json";
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Core/GGLog.cs
+++ b/UnityFrontend/Assets/Scripts/Core/GGLog.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace Gridiron.Core
+{
+    public static class GGLog
+    {
+        private static string LogFile
+        {
+            get { return GGPaths.Save("gg_log.txt"); }
+        }
+
+        public static void Info(string message)
+        {
+            Debug.Log(message);
+            Append("INFO", message);
+        }
+
+        public static void Warn(string message)
+        {
+            Debug.LogWarning(message);
+            Append("WARN", message);
+        }
+
+        public static void Error(string message)
+        {
+            Debug.LogError(message);
+            Append("ERROR", message);
+        }
+
+        private static void Append(string level, string message)
+        {
+#if !UNITY_EDITOR
+            try
+            {
+                File.AppendAllText(LogFile, string.Format("{0}: {1}{2}", level, message, Environment.NewLine));
+            }
+            catch
+            {
+            }
+#endif
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Core/GGPaths.cs
+++ b/UnityFrontend/Assets/Scripts/Core/GGPaths.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using UnityEngine;
+
+namespace Gridiron.Core
+{
+    public static class GGPaths
+    {
+        public static string Streaming(string file)
+        {
+            return Path.Combine(Application.streamingAssetsPath, file);
+        }
+
+        public static string Save(string file)
+        {
+            return Path.Combine(Application.persistentDataPath, file);
+        }
+
+        public static string Project(string relative)
+        {
+            var root = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            return Path.GetFullPath(Path.Combine(root, relative));
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Core/MiniJson.cs
+++ b/UnityFrontend/Assets/Scripts/Core/MiniJson.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Gridiron.Core
+{
+    // Minimal JSON parser based on MiniJSON (https://gist.github.com/darktable/1411710)
+    internal static class MiniJson
+    {
+        public static object Deserialize(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+            {
+                return null;
+            }
+            return Parser.Parse(json);
+        }
+
+        private sealed class Parser : IDisposable
+        {
+            private readonly string json;
+            private int index;
+
+            private Parser(string json)
+            {
+                this.json = json;
+            }
+
+            public static object Parse(string json)
+            {
+                using (var parser = new Parser(json))
+                {
+                    return parser.ParseValue();
+                }
+            }
+
+            public void Dispose()
+            {
+            }
+
+            private char PeekChar()
+            {
+                return json[index];
+            }
+
+            private char NextChar()
+            {
+                return json[index++];
+            }
+
+            private string NextWord()
+            {
+                var sb = new StringBuilder();
+                while (index < json.Length && !char.IsWhiteSpace(PeekChar()) && "{}[],:\"".IndexOf(PeekChar()) == -1)
+                {
+                    sb.Append(NextChar());
+                }
+                return sb.ToString();
+            }
+
+            private void EatWhitespace()
+            {
+                while (index < json.Length && char.IsWhiteSpace(PeekChar()))
+                {
+                    index++;
+                }
+            }
+
+            private object ParseValue()
+            {
+                EatWhitespace();
+                if (index == json.Length) return null;
+                char c = PeekChar();
+                switch (c)
+                {
+                    case '{':
+                        return ParseObject();
+                    case '[':
+                        return ParseArray();
+                    case '"':
+                        return ParseString();
+                    default:
+                        return ParseNumberOrWord();
+                }
+            }
+
+            private object ParseNumberOrWord()
+            {
+                string word = NextWord();
+                if (word == "true") return true;
+                if (word == "false") return false;
+                if (word == "null") return null;
+                if (long.TryParse(word, out var l)) return l;
+                if (double.TryParse(word, out var d)) return d;
+                return word;
+            }
+
+            private string ParseString()
+            {
+                var sb = new StringBuilder();
+                NextChar(); // skip opening quote
+                while (index < json.Length)
+                {
+                    char c = NextChar();
+                    if (c == '"') break;
+                    if (c == '\\')
+                    {
+                        if (index == json.Length) break;
+                        c = NextChar();
+                        switch (c)
+                        {
+                            case '\"': sb.Append('"'); break;
+                            case '\\': sb.Append('\\'); break;
+                            case '/': sb.Append('/'); break;
+                            case 'b': sb.Append('\b'); break;
+                            case 'f': sb.Append('\f'); break;
+                            case 'n': sb.Append('\n'); break;
+                            case 'r': sb.Append('\r'); break;
+                            case 't': sb.Append('\t'); break;
+                            case 'u':
+                                var hex = new char[4];
+                                for (int i = 0; i < 4; i++) hex[i] = NextChar();
+                                sb.Append((char)Convert.ToInt32(new string(hex), 16));
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                }
+                return sb.ToString();
+            }
+
+            private IDictionary ParseObject()
+            {
+                var dict = new Dictionary<string, object>();
+                NextChar(); // skip '{'
+                while (true)
+                {
+                    EatWhitespace();
+                    if (index < json.Length && PeekChar() == '}')
+                    {
+                        NextChar();
+                        break;
+                    }
+                    string key = ParseString();
+                    EatWhitespace();
+                    NextChar(); // skip ':'
+                    object value = ParseValue();
+                    dict[key] = value;
+                    EatWhitespace();
+                    if (index < json.Length && PeekChar() == ',')
+                    {
+                        NextChar();
+                    }
+                }
+                return dict;
+            }
+
+            private IList ParseArray()
+            {
+                var list = new List<object>();
+                NextChar(); // skip '['
+                bool done = false;
+                while (!done && index < json.Length)
+                {
+                    EatWhitespace();
+                    if (index < json.Length && PeekChar() == ']')
+                    {
+                        NextChar();
+                        break;
+                    }
+                    list.Add(ParseValue());
+                    EatWhitespace();
+                    if (index < json.Length && PeekChar() == ',')
+                    {
+                        NextChar();
+                    }
+                }
+                return list;
+            }
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Core/TeamProvider.cs
+++ b/UnityFrontend/Assets/Scripts/Core/TeamProvider.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Gridiron.Core
+{
+    public interface ITeamProvider
+    {
+        IEnumerable<string> GetAllTeamAbbrs();
+    }
+
+    public class TeamProvider : ITeamProvider
+    {
+        public IEnumerable<string> GetAllTeamAbbrs()
+        {
+            var results = new List<string>();
+            var path = GGPaths.Streaming(GGConventions.TeamsJsonFile);
+            try
+            {
+                if (File.Exists(path))
+                {
+                    var json = File.ReadAllText(path);
+                    var data = MiniJson.Deserialize(json) as List<object>;
+                    if (data != null)
+                    {
+                        foreach (var item in data)
+                        {
+                            var dict = item as Dictionary<string, object>;
+                            if (dict != null && dict.TryGetValue("abbr", out var abbrObj))
+                            {
+                                var abbr = abbrObj as string;
+                                if (!string.IsNullOrEmpty(abbr))
+                                {
+                                    results.Add(abbr);
+                                }
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    GGLog.Warn("Teams file missing: " + path);
+                }
+            }
+            catch (Exception ex)
+            {
+                GGLog.Error("TeamProvider error: " + ex.Message);
+            }
+            return results;
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Infra/GGLog.cs
+++ b/UnityFrontend/Assets/Scripts/Infra/GGLog.cs
@@ -1,0 +1,9 @@
+namespace Gridiron.Infra
+{
+    internal static class GGLog
+    {
+        public static void Info(string message) => Gridiron.Core.GGLog.Info(message);
+        public static void Warn(string message) => Gridiron.Core.GGLog.Warn(message);
+        public static void Error(string message) => Gridiron.Core.GGLog.Error(message);
+    }
+}

--- a/UnityFrontend/Assets/Scripts/Infra/SceneRoutes.cs
+++ b/UnityFrontend/Assets/Scripts/Infra/SceneRoutes.cs
@@ -1,0 +1,9 @@
+namespace Gridiron.Infra
+{
+    public static class SceneRoutes
+    {
+        public const string MainMenu = "MainMenu";
+        public const string TeamSelect = "TeamSelect";
+        public const string Dashboard = "Dashboard";
+    }
+}

--- a/UnityFrontend/Assets/Scripts/UI/Cap/ContractDetailPanel.cs
+++ b/UnityFrontend/Assets/Scripts/UI/Cap/ContractDetailPanel.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using Gridiron.Bridge.Dto;
+
+namespace Gridiron.UI.Cap
+{
+    internal class ContractDetailPanel : MonoBehaviour
+    {
+        [SerializeField] private TMP_Text rowTemplate;
+        [SerializeField] private Transform tableParent;
+
+        public void Show(ContractDTO contract, int currentYear)
+        {
+            if (tableParent == null)
+            {
+                var go = new GameObject("ContractTable", typeof(RectTransform), typeof(VerticalLayoutGroup));
+                go.transform.SetParent(transform, false);
+                tableParent = go.transform;
+            }
+
+            if (rowTemplate == null)
+            {
+                var rowObj = new GameObject("RowTemplate", typeof(RectTransform), typeof(TMP_Text));
+                rowObj.transform.SetParent(tableParent, false);
+                rowTemplate = rowObj.GetComponent<TMP_Text>();
+                rowTemplate.gameObject.SetActive(false);
+            }
+
+            foreach (Transform child in tableParent)
+            {
+                if (child != rowTemplate.transform)
+                {
+                    Destroy(child.gameObject);
+                }
+            }
+
+            if (contract == null || contract.Terms == null) return;
+
+            foreach (var term in contract.Terms)
+            {
+                if (term.Year == currentYear || term.Year == currentYear + 1)
+                {
+                    var inst = Instantiate(rowTemplate, tableParent);
+                    inst.gameObject.SetActive(true);
+                    inst.text = string.Format("{0}: {1}", term.Year, FormatMoney(CapHit(term)));
+                }
+            }
+        }
+
+        private long CapHit(ContractYearTerm t)
+        {
+            return t.Base + t.SigningProrated + t.RosterBonus + t.WorkoutBonus;
+        }
+
+        private string FormatMoney(long v)
+        {
+            return "$" + (v / 1_000_000f).ToString("0.0") + "M";
+        }
+    }
+}

--- a/UnityFrontend/Assets/Scripts/UI/Cap/TeamCapView.cs
+++ b/UnityFrontend/Assets/Scripts/UI/Cap/TeamCapView.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using Gridiron.Bridge.Validation;
+using Gridiron.Core;
+
+namespace Gridiron.UI.Cap
+{
+    internal class TeamCapView : MonoBehaviour
+    {
+        [SerializeField] private string teamAbbr;
+        [SerializeField] private int year;
+        [SerializeField] private TMP_Text banner;
+        [SerializeField] private TMP_Text rowTemplate;
+        [SerializeField] private Transform tableParent;
+
+        private void OnEnable()
+        {
+            if (tableParent == null)
+            {
+                var go = new GameObject("CapTable", typeof(RectTransform), typeof(VerticalLayoutGroup));
+                go.transform.SetParent(transform, false);
+                tableParent = go.transform;
+            }
+
+            if (rowTemplate == null)
+            {
+                var rowObj = new GameObject("RowTemplate", typeof(RectTransform), typeof(TMP_Text));
+                rowObj.transform.SetParent(tableParent, false);
+                rowTemplate = rowObj.GetComponent<TMP_Text>();
+                rowTemplate.gameObject.SetActive(false);
+            }
+
+            try
+            {
+                var path = string.Format("data/cap/capsheet_{0}.json", year);
+                var sheet = DataIO.LoadJson<CapsheetDTO>(path);
+                Render(sheet);
+            }
+            catch (GGDataException ex)
+            {
+                GGLog.Warn(ex.Message);
+                ShowBanner("Data version mismatch (" + ex.Code + ")");
+            }
+            catch (IOException)
+            {
+                ShowBanner("Capsheet missing");
+            }
+        }
+
+        private void Render(CapsheetDTO sheet)
+        {
+            foreach (Transform child in tableParent)
+            {
+                if (child != rowTemplate.transform)
+                {
+                    Destroy(child.gameObject);
+                }
+            }
+
+            if (sheet == null || sheet.Rows == null) return;
+
+            foreach (var row in sheet.Rows)
+            {
+                var inst = Instantiate(rowTemplate, tableParent);
+                inst.gameObject.SetActive(true);
+                inst.text = string.Format("{0} | {1}", row.PlayerName, FormatMoney(row.CapHit));
+            }
+
+            if (sheet.Totals != null)
+            {
+                var inst = Instantiate(rowTemplate, tableParent);
+                inst.gameObject.SetActive(true);
+                inst.text = string.Format("TOTAL | {0}", FormatMoney(sheet.Totals.CapHit));
+            }
+        }
+
+        private void ShowBanner(string msg)
+        {
+            if (banner == null)
+            {
+                var go = new GameObject("Banner", typeof(RectTransform), typeof(TMP_Text));
+                go.transform.SetParent(transform, false);
+                banner = go.GetComponent<TMP_Text>();
+                banner.color = Color.red;
+            }
+            banner.text = msg;
+        }
+
+        private string FormatMoney(long v)
+        {
+            return "$" + (v / 1_000_000f).ToString("0.0") + "M";
+        }
+
+        [Serializable]
+        private class CapsheetDTO
+        {
+            [Serializable]
+            public class Row
+            {
+                public string PlayerName;
+                public string TeamAbbr;
+                public int Year;
+                public long Base;
+                public long SigningProrated;
+                public long RosterBonus;
+                public long WorkoutBonus;
+                public long CapHit;
+                public long DeadCap;
+            }
+
+            public List<Row> Rows;
+            public Row Totals;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add core logging and path helpers
- parse contract JSON with forward-compatible DTOs and validation
- render team cap sheet and contract detail panels with TextMeshPro

## Testing
- `csc UnityFrontend/Assets/Scripts/Core/GGLog.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ffda9c2f083279fff4e795081e45c